### PR TITLE
Revamp UserProfile: Remove tabs, add sections, fix family members visibility

### DIFF
--- a/frontend/src/__tests__/UserProfile.test.tsx
+++ b/frontend/src/__tests__/UserProfile.test.tsx
@@ -1,0 +1,172 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import { UserProfile } from '../components/UserProfile';
+import { useAuth } from '../contexts/AuthContext';
+import { useFamily } from '../contexts/FamilyContext';
+import { familyApi } from '../services/api';
+
+// Mock the contexts
+vi.mock('../contexts/AuthContext');
+vi.mock('../contexts/FamilyContext');
+vi.mock('../services/api');
+
+// Mock react-i18next
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+const mockUseAuth = useAuth as any;
+const mockUseFamily = useFamily as any;
+const mockFamilyApi = familyApi as any;
+
+const mockUser = {
+  id: '1',
+  firstName: 'Test',
+  lastName: 'User',
+  email: 'test@example.com',
+  avatarUrl: null,
+  createdAt: '2023-01-01T00:00:00Z',
+  updatedAt: '2023-01-01T00:00:00Z',
+};
+
+const mockFamily = {
+  id: '1',
+  name: 'Test Family',
+  userRole: 'MEMBER',
+  createdAt: '2023-01-01T00:00:00Z',
+  updatedAt: '2023-01-01T00:00:00Z',
+  creator: {
+    id: '1',
+    firstName: 'Test',
+    lastName: 'Creator',
+    email: 'creator@example.com',
+  },
+  memberCount: 2,
+};
+
+const mockFamilyAdmin = {
+  ...mockFamily,
+  userRole: 'ADMIN',
+};
+
+const mockMembers = [
+  {
+    id: '1',
+    familyId: '1',
+    userId: '1',
+    role: 'ADMIN',
+    joinedAt: '2023-01-01T00:00:00Z',
+    user: {
+      id: '1',
+      firstName: 'Admin',
+      lastName: 'User',
+      email: 'admin@example.com',
+      avatarUrl: null,
+    },
+  },
+  {
+    id: '2',
+    familyId: '1',
+    userId: '2',
+    role: 'MEMBER',
+    joinedAt: '2023-01-02T00:00:00Z',
+    user: {
+      id: '2',
+      firstName: 'Member',
+      lastName: 'User',
+      email: 'member@example.com',
+      avatarUrl: null,
+    },
+  },
+];
+
+describe('UserProfile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    
+    mockUseAuth.mockReturnValue({
+      user: mockUser,
+      refreshUser: vi.fn(),
+    });
+
+    mockFamilyApi.getMembers.mockResolvedValue({
+      data: {
+        success: true,
+        data: mockMembers,
+      },
+    });
+
+    mockFamilyApi.getInvites.mockResolvedValue({
+      data: {
+        success: true,
+        data: [],
+      },
+    });
+
+    mockFamilyApi.getJoinRequests.mockResolvedValue({
+      data: {
+        success: true,
+        data: [],
+      },
+    });
+  });
+
+  it('loads family members for non-admin users', async () => {
+    mockUseFamily.mockReturnValue({
+      currentFamily: mockFamily, // MEMBER role
+    });
+
+    render(<UserProfile onClose={vi.fn()} />);
+
+    // Wait for the component to load family data
+    await waitFor(() => {
+      expect(mockFamilyApi.getMembers).toHaveBeenCalledWith('1');
+    });
+
+    // Should not call admin-only endpoints
+    expect(mockFamilyApi.getInvites).not.toHaveBeenCalled();
+    expect(mockFamilyApi.getJoinRequests).not.toHaveBeenCalled();
+
+    // Should display family members section
+    expect(screen.getByText('family.members')).toBeInTheDocument();
+  });
+
+  it('loads family members and admin data for admin users', async () => {
+    mockUseFamily.mockReturnValue({
+      currentFamily: mockFamilyAdmin, // ADMIN role
+    });
+
+    render(<UserProfile onClose={vi.fn()} />);
+
+    // Wait for the component to load family data
+    await waitFor(() => {
+      expect(mockFamilyApi.getMembers).toHaveBeenCalledWith('1');
+      expect(mockFamilyApi.getInvites).toHaveBeenCalledWith('1');
+      expect(mockFamilyApi.getJoinRequests).toHaveBeenCalledWith('1');
+    });
+
+    // Should display family members section
+    expect(screen.getByText('family.members')).toBeInTheDocument();
+    // Should display admin sections
+    expect(screen.getByRole('heading', { name: 'family.generateInvite' })).toBeInTheDocument();
+  });
+
+  it('does not load family data when no current family', async () => {
+    mockUseFamily.mockReturnValue({
+      currentFamily: null,
+    });
+
+    render(<UserProfile onClose={vi.fn()} />);
+
+    // Should not call any family API endpoints
+    expect(mockFamilyApi.getMembers).not.toHaveBeenCalled();
+    expect(mockFamilyApi.getInvites).not.toHaveBeenCalled();
+    expect(mockFamilyApi.getJoinRequests).not.toHaveBeenCalled();
+
+    // Should not display family management section
+    expect(screen.queryByText('user.familyManagement')).not.toBeInTheDocument();
+  });
+}); 

--- a/frontend/src/components/UserProfile.css
+++ b/frontend/src/components/UserProfile.css
@@ -28,7 +28,7 @@
   border-radius: 12px;
   box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
   width: 100%;
-  max-width: 500px;
+  max-width: 900px;
   max-height: 90vh;
   overflow: hidden;
   animation: user-profile-modal-slide-in 0.2s ease-out;
@@ -88,49 +88,10 @@
   ring-offset: 2px;
 }
 
-/* Tabs */
-.user-profile-tabs {
-  display: flex;
-  background-color: #f9fafb;
-  border-bottom: 1px solid #e5e7eb;
-}
-
-.user-profile-tab {
-  flex: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-  padding: 1rem;
-  background: none;
-  border: none;
-  font-size: 0.875rem;
-  font-weight: 500;
-  color: #6b7280;
-  cursor: pointer;
-  transition: all 0.15s ease;
-  border-bottom: 2px solid transparent;
-}
-
-.user-profile-tab:hover {
-  color: #374151;
-  background-color: #f3f4f6;
-}
-
-.user-profile-tab-active {
-  color: #7c3aed;
-  border-bottom-color: #7c3aed;
-  background-color: #ffffff;
-}
-
-.user-profile-tab svg {
-  flex-shrink: 0;
-}
-
 /* Content */
 .user-profile-content {
   padding: 2rem;
-  max-height: 60vh;
+  max-height: 80vh;
   overflow-y: auto;
 }
 
@@ -155,11 +116,102 @@
   border: 1px solid #fecaca;
 }
 
+/* Sections */
+.user-profile-section {
+  margin-bottom: 2.5rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.75rem;
+  background-color: #ffffff;
+  overflow: hidden;
+}
+
+.user-profile-section-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1.25rem 1.5rem;
+  background-color: #f9fafb;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.user-profile-section-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  background-color: #7c3aed;
+  color: #ffffff;
+  border-radius: 0.5rem;
+  flex-shrink: 0;
+}
+
+.user-profile-section-title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: #111827;
+  margin: 0;
+  flex: 1;
+}
+
+.user-profile-family-name {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #6b7280;
+  background-color: #e5e7eb;
+  padding: 0.25rem 0.75rem;
+  border-radius: 1rem;
+}
+
+/* Subsections */
+.user-profile-subsection {
+  padding: 1.5rem;
+  border-bottom: 1px solid #f3f4f6;
+}
+
+.user-profile-subsection:last-child {
+  border-bottom: none;
+}
+
+.user-profile-subsection-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #374151;
+  margin: 0 0 1rem 0;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.user-profile-count-badge {
+  background-color: #dc2626;
+  color: #ffffff;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.125rem 0.5rem;
+  border-radius: 1rem;
+  min-width: 1.25rem;
+  text-align: center;
+}
+
 /* Form */
 .user-profile-form {
+  padding: 1.5rem;
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+}
+
+.user-profile-form-row {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.5rem;
+}
+
+@media (min-width: 640px) {
+  .user-profile-form-row {
+    grid-template-columns: 1fr 1fr;
+  }
 }
 
 .user-profile-form-group {
@@ -234,11 +286,20 @@
   transition: all 0.15s ease;
   border: 1px solid transparent;
   min-width: 100px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .user-profile-button:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+}
+
+.user-profile-button-sm {
+  padding: 0.5rem 1rem;
+  font-size: 0.75rem;
+  min-width: 80px;
 }
 
 .user-profile-button-primary {
@@ -277,39 +338,257 @@
   ring-offset: 2px;
 }
 
+.user-profile-button-success {
+  background-color: #10b981;
+  color: #ffffff;
+  border-color: #10b981;
+}
+
+.user-profile-button-success:hover:not(:disabled) {
+  background-color: #059669;
+  border-color: #059669;
+}
+
+.user-profile-button-danger {
+  background-color: #dc2626;
+  color: #ffffff;
+  border-color: #dc2626;
+}
+
+.user-profile-button-danger:hover:not(:disabled) {
+  background-color: #b91c1c;
+  border-color: #b91c1c;
+}
+
+/* Family Management Components */
+.user-profile-members-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.user-profile-member-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem;
+  background-color: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+}
+
+.user-profile-member-info {
+  flex: 1;
+}
+
+.user-profile-member-name {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #111827;
+  margin-bottom: 0.25rem;
+}
+
+.user-profile-member-email {
+  font-size: 0.75rem;
+  color: #6b7280;
+}
+
+.user-profile-member-role {
+  flex-shrink: 0;
+}
+
+.user-profile-role-badge {
+  padding: 0.25rem 0.75rem;
+  border-radius: 1rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+}
+
+.user-profile-role-admin {
+  background-color: #fef3c7;
+  color: #92400e;
+}
+
+.user-profile-role-member {
+  background-color: #e0e7ff;
+  color: #3730a3;
+}
+
+/* Join Requests */
+.user-profile-requests-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.user-profile-request-card {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 1rem;
+  background-color: #fef9e7;
+  border: 1px solid #f59e0b;
+  border-radius: 0.5rem;
+  gap: 1rem;
+}
+
+.user-profile-request-info {
+  flex: 1;
+}
+
+.user-profile-request-name {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #111827;
+  margin-bottom: 0.25rem;
+}
+
+.user-profile-request-email {
+  font-size: 0.75rem;
+  color: #6b7280;
+  margin-bottom: 0.5rem;
+}
+
+.user-profile-request-message {
+  font-size: 0.75rem;
+  color: #374151;
+  font-style: italic;
+  margin-bottom: 0.5rem;
+  padding: 0.5rem;
+  background-color: #ffffff;
+  border-radius: 0.25rem;
+  border-left: 3px solid #f59e0b;
+}
+
+.user-profile-request-date {
+  font-size: 0.75rem;
+  color: #6b7280;
+}
+
+.user-profile-request-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+/* Invite Form */
+.user-profile-invite-form {
+  background-color: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+
+/* Invites List */
+.user-profile-invites-list {
+  margin-top: 1rem;
+}
+
+.user-profile-invites-title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #374151;
+  margin: 0 0 0.75rem 0;
+}
+
+.user-profile-invite-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem;
+  background-color: #f0fdf4;
+  border: 1px solid #bbf7d0;
+  border-radius: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.user-profile-invite-info {
+  flex: 1;
+}
+
+.user-profile-invite-code {
+  font-size: 0.875rem;
+  font-weight: 600;
+  font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+  color: #111827;
+  background-color: #ffffff;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  border: 1px solid #d1d5db;
+  display: inline-block;
+  margin-bottom: 0.25rem;
+}
+
+.user-profile-invite-email {
+  font-size: 0.75rem;
+  color: #6b7280;
+  margin-bottom: 0.25rem;
+}
+
+.user-profile-invite-expiry {
+  font-size: 0.75rem;
+  color: #6b7280;
+}
+
 /* Responsive Design */
 @media (max-width: 768px) {
   .user-profile-overlay {
     padding: 0.5rem;
   }
-  
+
   .user-profile-modal {
-    max-width: none;
-    margin: 0;
+    max-width: 100%;
+    max-height: 95vh;
   }
-  
+
   .user-profile-header {
     padding: 1rem 1.5rem;
   }
-  
+
   .user-profile-content {
-    padding: 1.5rem;
-    max-height: 70vh;
+    padding: 1rem;
+    max-height: 85vh;
   }
-  
-  .user-profile-tabs {
+
+  .user-profile-section-header {
+    padding: 1rem;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .user-profile-section-title {
+    font-size: 1rem;
+  }
+
+  .user-profile-form {
+    padding: 1rem;
+  }
+
+  .user-profile-form-row {
+    grid-template-columns: 1fr;
+  }
+
+  .user-profile-form-actions {
     flex-direction: column;
   }
-  
-  .user-profile-tab {
-    padding: 0.75rem 1rem;
-    border-bottom: none;
-    border-right: 2px solid transparent;
+
+  .user-profile-button {
+    width: 100%;
   }
-  
-  .user-profile-tab-active {
-    border-right-color: #7c3aed;
-    border-bottom-color: transparent;
+
+  .user-profile-member-card,
+  .user-profile-request-card {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .user-profile-request-actions {
+    width: 100%;
+    justify-content: flex-end;
   }
 }
 
@@ -317,19 +596,20 @@
   .user-profile-header {
     padding: 0.75rem 1rem;
   }
-  
+
   .user-profile-content {
-    padding: 1rem;
+    padding: 0.75rem;
   }
-  
+
   .user-profile-form-actions {
-    flex-direction: column;
+    gap: 0.5rem;
   }
-  
+
   .user-profile-button {
-    width: 100%;
+    padding: 0.625rem 1rem;
+    font-size: 0.8125rem;
   }
-  
+
   .user-profile-title {
     font-size: 1.125rem;
   }

--- a/frontend/src/components/UserProfile.tsx
+++ b/frontend/src/components/UserProfile.tsx
@@ -1,9 +1,8 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import { useFamily } from '../contexts/FamilyContext';
-import { userApi, ChangePasswordData } from '../services/api';
-import { FamilyManagement } from './FamilyManagement';
+import { userApi, familyApi, ChangePasswordData, FamilyMember, FamilyInvite, FamilyJoinRequest } from '../services/api';
 import './UserProfile.css';
 
 interface UserProfileProps {
@@ -14,7 +13,8 @@ export const UserProfile: React.FC<UserProfileProps> = ({ onClose }) => {
   const { t } = useTranslation();
   const { user, refreshUser } = useAuth();
   const { currentFamily } = useFamily();
-  const [activeTab, setActiveTab] = useState<'profile' | 'password' | 'family'>('profile');
+  const modalRef = useRef<HTMLDivElement>(null);
+  
   const [isLoading, setIsLoading] = useState(false);
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
 
@@ -31,8 +31,68 @@ export const UserProfile: React.FC<UserProfileProps> = ({ onClose }) => {
     confirmPassword: '',
   });
 
+  // Family management state
+  const [members, setMembers] = useState<FamilyMember[]>([]);
+  const [invites, setInvites] = useState<FamilyInvite[]>([]);
+  const [joinRequests, setJoinRequests] = useState<FamilyJoinRequest[]>([]);
+  const [isCreatingInvite, setIsCreatingInvite] = useState(false);
+  const [inviteEmail, setInviteEmail] = useState('');
+  const [inviteExpiry, setInviteExpiry] = useState(7);
+
   const [profileErrors, setProfileErrors] = useState<Record<string, string>>({});
   const [passwordErrors, setPasswordErrors] = useState<Record<string, string>>({});
+
+  const isAdmin = currentFamily?.userRole === 'ADMIN';
+
+  // Click outside to close
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (modalRef.current && !modalRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [onClose]);
+
+  // Load family data when component mounts
+  useEffect(() => {
+    if (currentFamily) {
+      loadFamilyData();
+    }
+  }, [currentFamily]);
+
+  const loadFamilyData = async () => {
+    if (!currentFamily) return;
+
+    try {
+      // Always load members for all family members
+      const membersResponse = await familyApi.getMembers(currentFamily.id);
+      if (membersResponse.data.success) {
+        setMembers(membersResponse.data.data);
+      }
+
+      // Only load invites and join requests for admins
+      if (isAdmin) {
+        const [invitesResponse, joinRequestsResponse] = await Promise.all([
+          familyApi.getInvites(currentFamily.id),
+          familyApi.getJoinRequests(currentFamily.id),
+        ]);
+
+        if (invitesResponse.data.success) {
+          setInvites(invitesResponse.data.data);
+        }
+        if (joinRequestsResponse.data.success) {
+          setJoinRequests(joinRequestsResponse.data.data);
+        }
+      }
+    } catch (error) {
+      // Handle silently
+    }
+  };
 
   const validateProfileForm = (): boolean => {
     const errors: Record<string, string> = {};
@@ -86,10 +146,6 @@ export const UserProfile: React.FC<UserProfileProps> = ({ onClose }) => {
       await userApi.update(user.id, profileData);
       await refreshUser();
       setMessage({ type: 'success', text: t('user.profileUpdated') });
-      // Close dialog after successful save
-      setTimeout(() => {
-        onClose();
-      }, 1500); // Show success message briefly before closing
     } catch (error: any) {
       setMessage({ 
         type: 'error', 
@@ -125,10 +181,6 @@ export const UserProfile: React.FC<UserProfileProps> = ({ onClose }) => {
         confirmPassword: '',
       });
       setPasswordErrors({});
-      // Close dialog after successful password change
-      setTimeout(() => {
-        onClose();
-      }, 1500); // Show success message briefly before closing
     } catch (error: any) {
       setMessage({ 
         type: 'error', 
@@ -136,6 +188,68 @@ export const UserProfile: React.FC<UserProfileProps> = ({ onClose }) => {
       });
     } finally {
       setIsLoading(false);
+    }
+  };
+
+  const handleCreateInvite = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!currentFamily) return;
+
+    setIsCreatingInvite(true);
+    try {
+      const inviteData: { receiverEmail?: string; expiresIn?: number } = {
+        expiresIn: inviteExpiry,
+      };
+      
+      if (inviteEmail.trim()) {
+        inviteData.receiverEmail = inviteEmail;
+      }
+      
+      const response = await familyApi.createInvite(currentFamily.id, inviteData);
+
+      if (response.data.success) {
+        setInvites(prev => [response.data.data, ...prev]);
+        setInviteEmail('');
+        setMessage({ type: 'success', text: t('family.inviteCreated') });
+      }
+    } catch (error: any) {
+      setMessage({ 
+        type: 'error', 
+        text: error.response?.data?.message || t('family.inviteError') 
+      });
+    } finally {
+      setIsCreatingInvite(false);
+    }
+  };
+
+  const handleJoinRequestResponse = async (requestId: string, response: 'APPROVED' | 'REJECTED') => {
+    try {
+      const result = await familyApi.respondToJoinRequest(requestId, response);
+      
+      if (result.data.success) {
+        setJoinRequests(prev => 
+          prev.map(req => 
+            req.id === requestId 
+              ? { ...req, status: response, respondedAt: new Date().toISOString() }
+              : req
+          )
+        );
+        
+        if (response === 'APPROVED') {
+          // Refresh members list
+          loadFamilyData();
+        }
+        
+        setMessage({ 
+          type: 'success', 
+          text: response === 'APPROVED' ? t('family.requestApproved') : t('family.requestRejected')
+        });
+      }
+    } catch (error: any) {
+      setMessage({ 
+        type: 'error', 
+        text: error.response?.data?.message || t('family.requestError') 
+      });
     }
   };
 
@@ -163,9 +277,11 @@ export const UserProfile: React.FC<UserProfileProps> = ({ onClose }) => {
     return null;
   }
 
+  const pendingJoinRequests = joinRequests.filter(req => req.status === 'PENDING');
+
   return (
     <div className="user-profile-overlay">
-      <div className="user-profile-modal">
+      <div className="user-profile-modal" ref={modalRef}>
         <div className="user-profile-header">
           <h2 className="user-profile-title">{t('user.profile')}</h2>
           <button
@@ -181,47 +297,6 @@ export const UserProfile: React.FC<UserProfileProps> = ({ onClose }) => {
           </button>
         </div>
 
-        <div className="user-profile-tabs">
-          <button
-            onClick={() => setActiveTab('profile')}
-            className={`user-profile-tab ${activeTab === 'profile' ? 'user-profile-tab-active' : ''}`}
-            type="button"
-          >
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-              <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
-              <circle cx="12" cy="7" r="4" />
-            </svg>
-            {t('user.personalInfo')}
-          </button>
-          <button
-            onClick={() => setActiveTab('password')}
-            className={`user-profile-tab ${activeTab === 'password' ? 'user-profile-tab-active' : ''}`}
-            type="button"
-          >
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-              <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
-              <circle cx="12" cy="16" r="1" />
-              <path d="M7 11V7a5 5 0 0 1 10 0v4" />
-            </svg>
-            {t('user.changePassword')}
-          </button>
-          {currentFamily && (
-            <button
-              onClick={() => setActiveTab('family')}
-              className={`user-profile-tab ${activeTab === 'family' ? 'user-profile-tab-active' : ''}`}
-              type="button"
-            >
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/>
-                <circle cx="9" cy="7" r="4"/>
-                <path d="M23 21v-2a4 4 0 0 0-3-3.87"/>
-                <path d="M16 3.13a4 4 0 0 1 0 7.75"/>
-              </svg>
-              {t('user.familyManagement')}
-            </button>
-          )}
-        </div>
-
         <div className="user-profile-content">
           {message && (
             <div className={`user-profile-message user-profile-message-${message.type}`}>
@@ -229,145 +304,160 @@ export const UserProfile: React.FC<UserProfileProps> = ({ onClose }) => {
             </div>
           )}
 
-          {activeTab === 'profile' && (
+          {/* Personal Information Section */}
+          <section className="user-profile-section">
+            <div className="user-profile-section-header">
+              <div className="user-profile-section-icon">
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+                  <circle cx="12" cy="7" r="4" />
+                </svg>
+              </div>
+              <h3 className="user-profile-section-title">{t('user.personalInfo')}</h3>
+            </div>
+
             <form onSubmit={handleProfileSubmit} className="user-profile-form">
-              <div className="user-profile-form-group">
-                <label htmlFor="email" className="user-profile-label">
-                  {t('user.email')}
-                </label>
-                <input
-                  type="email"
-                  id="email"
-                  value={user.email}
-                  className="user-profile-input user-profile-input-disabled"
-                  disabled
-                />
-                <span className="user-profile-help">
-                  {t('user.emailNotEditable')}
-                </span>
+              <div className="user-profile-form-row">
+                <div className="user-profile-form-group">
+                  <label htmlFor="email" className="user-profile-label">
+                    {t('user.email')}
+                  </label>
+                  <input
+                    type="email"
+                    id="email"
+                    value={user.email}
+                    className="user-profile-input user-profile-input-disabled"
+                    disabled
+                  />
+                  <span className="user-profile-help">
+                    {t('user.emailNotEditable')}
+                  </span>
+                </div>
               </div>
 
-              <div className="user-profile-form-group">
-                <label htmlFor="firstName" className="user-profile-label">
-                  {t('user.firstName')}
-                </label>
-                <input
-                  type="text"
-                  id="firstName"
-                  name="firstName"
-                  value={profileData.firstName}
-                  onChange={handleProfileInputChange}
-                  className={`user-profile-input ${profileErrors['firstName'] ? 'user-profile-input-error' : ''}`}
-                  disabled={isLoading}
-                />
-                                 {profileErrors['firstName'] && (
-                   <span className="user-profile-error">{profileErrors['firstName']}</span>
-                 )}
-              </div>
+              <div className="user-profile-form-row">
+                <div className="user-profile-form-group">
+                  <label htmlFor="firstName" className="user-profile-label">
+                    {t('user.firstName')}
+                  </label>
+                  <input
+                    type="text"
+                    id="firstName"
+                    name="firstName"
+                    value={profileData.firstName}
+                    onChange={handleProfileInputChange}
+                    className={`user-profile-input ${profileErrors['firstName'] ? 'user-profile-input-error' : ''}`}
+                    disabled={isLoading}
+                  />
+                  {profileErrors['firstName'] && (
+                    <span className="user-profile-error">{profileErrors['firstName']}</span>
+                  )}
+                </div>
 
-              <div className="user-profile-form-group">
-                <label htmlFor="lastName" className="user-profile-label">
-                  {t('user.lastName')}
-                </label>
-                <input
-                  type="text"
-                  id="lastName"
-                  name="lastName"
-                  value={profileData.lastName}
-                  onChange={handleProfileInputChange}
-                  className={`user-profile-input ${profileErrors['lastName'] ? 'user-profile-input-error' : ''}`}
-                  disabled={isLoading}
-                />
-                {profileErrors['lastName'] && (
-                  <span className="user-profile-error">{profileErrors['lastName']}</span>
-                )}
+                <div className="user-profile-form-group">
+                  <label htmlFor="lastName" className="user-profile-label">
+                    {t('user.lastName')}
+                  </label>
+                  <input
+                    type="text"
+                    id="lastName"
+                    name="lastName"
+                    value={profileData.lastName}
+                    onChange={handleProfileInputChange}
+                    className={`user-profile-input ${profileErrors['lastName'] ? 'user-profile-input-error' : ''}`}
+                    disabled={isLoading}
+                  />
+                  {profileErrors['lastName'] && (
+                    <span className="user-profile-error">{profileErrors['lastName']}</span>
+                  )}
+                </div>
               </div>
 
               <div className="user-profile-form-actions">
-                <button
-                  type="button"
-                  onClick={onClose}
-                  className="user-profile-button user-profile-button-secondary"
-                  disabled={isLoading}
-                >
-                  {t('common.cancel')}
-                </button>
                 <button
                   type="submit"
                   className="user-profile-button user-profile-button-primary"
                   disabled={isLoading}
                 >
-                  {isLoading ? t('common.saving') : t('common.save')}
+                  {isLoading ? t('common.saving') : t('user.updateProfile')}
                 </button>
               </div>
             </form>
-          )}
+          </section>
 
-          {activeTab === 'password' && (
+          {/* Change Password Section */}
+          <section className="user-profile-section">
+            <div className="user-profile-section-header">
+              <div className="user-profile-section-icon">
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+                  <circle cx="12" cy="16" r="1" />
+                  <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+                </svg>
+              </div>
+              <h3 className="user-profile-section-title">{t('user.changePassword')}</h3>
+            </div>
+
             <form onSubmit={handlePasswordSubmit} className="user-profile-form">
-              <div className="user-profile-form-group">
-                <label htmlFor="currentPassword" className="user-profile-label">
-                  {t('user.currentPassword')}
-                </label>
-                <input
-                  type="password"
-                  id="currentPassword"
-                  name="currentPassword"
-                  value={passwordData.currentPassword}
-                  onChange={handlePasswordInputChange}
-                  className={`user-profile-input ${passwordErrors['currentPassword'] ? 'user-profile-input-error' : ''}`}
-                  disabled={isLoading}
-                />
-                {passwordErrors['currentPassword'] && (
-                  <span className="user-profile-error">{passwordErrors['currentPassword']}</span>
-                )}
+              <div className="user-profile-form-row">
+                <div className="user-profile-form-group">
+                  <label htmlFor="currentPassword" className="user-profile-label">
+                    {t('user.currentPassword')}
+                  </label>
+                  <input
+                    type="password"
+                    id="currentPassword"
+                    name="currentPassword"
+                    value={passwordData.currentPassword}
+                    onChange={handlePasswordInputChange}
+                    className={`user-profile-input ${passwordErrors['currentPassword'] ? 'user-profile-input-error' : ''}`}
+                    disabled={isLoading}
+                  />
+                  {passwordErrors['currentPassword'] && (
+                    <span className="user-profile-error">{passwordErrors['currentPassword']}</span>
+                  )}
+                </div>
               </div>
 
-              <div className="user-profile-form-group">
-                <label htmlFor="newPassword" className="user-profile-label">
-                  {t('user.newPassword')}
-                </label>
-                <input
-                  type="password"
-                  id="newPassword"
-                  name="newPassword"
-                  value={passwordData.newPassword}
-                  onChange={handlePasswordInputChange}
-                  className={`user-profile-input ${passwordErrors['newPassword'] ? 'user-profile-input-error' : ''}`}
-                  disabled={isLoading}
-                />
-                {passwordErrors['newPassword'] && (
-                  <span className="user-profile-error">{passwordErrors['newPassword']}</span>
-                )}
-              </div>
+              <div className="user-profile-form-row">
+                <div className="user-profile-form-group">
+                  <label htmlFor="newPassword" className="user-profile-label">
+                    {t('user.newPassword')}
+                  </label>
+                  <input
+                    type="password"
+                    id="newPassword"
+                    name="newPassword"
+                    value={passwordData.newPassword}
+                    onChange={handlePasswordInputChange}
+                    className={`user-profile-input ${passwordErrors['newPassword'] ? 'user-profile-input-error' : ''}`}
+                    disabled={isLoading}
+                  />
+                  {passwordErrors['newPassword'] && (
+                    <span className="user-profile-error">{passwordErrors['newPassword']}</span>
+                  )}
+                </div>
 
-              <div className="user-profile-form-group">
-                <label htmlFor="confirmPassword" className="user-profile-label">
-                  {t('user.confirmNewPassword')}
-                </label>
-                <input
-                  type="password"
-                  id="confirmPassword"
-                  name="confirmPassword"
-                  value={passwordData.confirmPassword}
-                  onChange={handlePasswordInputChange}
-                  className={`user-profile-input ${passwordErrors['confirmPassword'] ? 'user-profile-input-error' : ''}`}
-                  disabled={isLoading}
-                />
-                {passwordErrors['confirmPassword'] && (
-                  <span className="user-profile-error">{passwordErrors['confirmPassword']}</span>
-                )}
+                <div className="user-profile-form-group">
+                  <label htmlFor="confirmPassword" className="user-profile-label">
+                    {t('user.confirmNewPassword')}
+                  </label>
+                  <input
+                    type="password"
+                    id="confirmPassword"
+                    name="confirmPassword"
+                    value={passwordData.confirmPassword}
+                    onChange={handlePasswordInputChange}
+                    className={`user-profile-input ${passwordErrors['confirmPassword'] ? 'user-profile-input-error' : ''}`}
+                    disabled={isLoading}
+                  />
+                  {passwordErrors['confirmPassword'] && (
+                    <span className="user-profile-error">{passwordErrors['confirmPassword']}</span>
+                  )}
+                </div>
               </div>
 
               <div className="user-profile-form-actions">
-                <button
-                  type="button"
-                  onClick={onClose}
-                  className="user-profile-button user-profile-button-secondary"
-                  disabled={isLoading}
-                >
-                  {t('common.cancel')}
-                </button>
                 <button
                   type="submit"
                   className="user-profile-button user-profile-button-primary"
@@ -377,10 +467,170 @@ export const UserProfile: React.FC<UserProfileProps> = ({ onClose }) => {
                 </button>
               </div>
             </form>
-          )}
+          </section>
 
-          {activeTab === 'family' && currentFamily && (
-            <FamilyManagement />
+          {/* Family Management Section - Only for family members */}
+          {currentFamily && (
+            <section className="user-profile-section">
+              <div className="user-profile-section-header">
+                <div className="user-profile-section-icon">
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                    <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/>
+                    <circle cx="9" cy="7" r="4"/>
+                    <path d="M23 21v-2a4 4 0 0 0-3-3.87"/>
+                    <path d="M16 3.13a4 4 0 0 1 0 7.75"/>
+                  </svg>
+                </div>
+                <h3 className="user-profile-section-title">{t('user.familyManagement')}</h3>
+                <span className="user-profile-family-name">{currentFamily.name}</span>
+              </div>
+
+              {/* Family Members */}
+              <div className="user-profile-subsection">
+                <h4 className="user-profile-subsection-title">{t('family.members')}</h4>
+                <div className="user-profile-members-list">
+                  {members.map((member) => (
+                    <div key={member.id} className="user-profile-member-card">
+                      <div className="user-profile-member-info">
+                        <div className="user-profile-member-name">
+                          {member.user?.firstName} {member.user?.lastName}
+                        </div>
+                        <div className="user-profile-member-email">{member.user?.email}</div>
+                      </div>
+                      <div className="user-profile-member-role">
+                        <span className={`user-profile-role-badge user-profile-role-${member.role.toLowerCase()}`}>
+                          {t(`family.role.${member.role.toLowerCase()}`)}
+                        </span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {/* Admin-only sections */}
+              {isAdmin && (
+                <>
+                  {/* Pending Join Requests */}
+                  {pendingJoinRequests.length > 0 && (
+                    <div className="user-profile-subsection">
+                      <h4 className="user-profile-subsection-title">
+                        {t('family.joinRequests')} 
+                        <span className="user-profile-count-badge">{pendingJoinRequests.length}</span>
+                      </h4>
+                      <div className="user-profile-requests-list">
+                        {pendingJoinRequests.map((request) => (
+                          <div key={request.id} className="user-profile-request-card">
+                            <div className="user-profile-request-info">
+                              <div className="user-profile-request-name">
+                                {request.user.firstName} {request.user.lastName}
+                              </div>
+                              <div className="user-profile-request-email">{request.user.email}</div>
+                              {request.message && (
+                                <div className="user-profile-request-message">"{request.message}"</div>
+                              )}
+                              <div className="user-profile-request-date">
+                                {new Date(request.createdAt).toLocaleDateString()}
+                              </div>
+                            </div>
+                            <div className="user-profile-request-actions">
+                              <button
+                                onClick={() => handleJoinRequestResponse(request.id, 'APPROVED')}
+                                className="user-profile-button user-profile-button-success user-profile-button-sm"
+                              >
+                                {t('family.approve')}
+                              </button>
+                              <button
+                                onClick={() => handleJoinRequestResponse(request.id, 'REJECTED')}
+                                className="user-profile-button user-profile-button-danger user-profile-button-sm"
+                              >
+                                {t('family.reject')}
+                              </button>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Generate Invite */}
+                  <div className="user-profile-subsection">
+                    <h4 className="user-profile-subsection-title">{t('family.generateInvite')}</h4>
+                    <form onSubmit={handleCreateInvite} className="user-profile-invite-form">
+                      <div className="user-profile-form-row">
+                        <div className="user-profile-form-group">
+                          <label htmlFor="inviteEmail" className="user-profile-label">
+                            {t('family.inviteEmail')} ({t('common.optional')})
+                          </label>
+                          <input
+                            type="email"
+                            id="inviteEmail"
+                            value={inviteEmail}
+                            onChange={(e) => setInviteEmail(e.target.value)}
+                            className="user-profile-input"
+                            placeholder={t('family.inviteEmailPlaceholder')}
+                            disabled={isCreatingInvite}
+                          />
+                        </div>
+                        <div className="user-profile-form-group">
+                          <label htmlFor="inviteExpiry" className="user-profile-label">
+                            {t('family.expiresIn')}
+                          </label>
+                          <select
+                            id="inviteExpiry"
+                            value={inviteExpiry}
+                            onChange={(e) => setInviteExpiry(Number(e.target.value))}
+                            className="user-profile-input"
+                            disabled={isCreatingInvite}
+                          >
+                            <option value={1}>{t('family.expiry.1day')}</option>
+                            <option value={3}>{t('family.expiry.3days')}</option>
+                            <option value={7}>{t('family.expiry.7days')}</option>
+                            <option value={14}>{t('family.expiry.14days')}</option>
+                            <option value={30}>{t('family.expiry.30days')}</option>
+                          </select>
+                        </div>
+                      </div>
+                      <div className="user-profile-form-actions">
+                        <button
+                          type="submit"
+                          className="user-profile-button user-profile-button-primary"
+                          disabled={isCreatingInvite}
+                        >
+                          {isCreatingInvite ? t('family.generatingInvite') : t('family.generateInvite')}
+                        </button>
+                      </div>
+                    </form>
+
+                    {/* Active Invites */}
+                    {invites.length > 0 && (
+                      <div className="user-profile-invites-list">
+                        <h5 className="user-profile-invites-title">{t('family.activeInvites')}</h5>
+                        {invites.filter(invite => invite.status === 'PENDING').map((invite) => (
+                          <div key={invite.id} className="user-profile-invite-card">
+                            <div className="user-profile-invite-info">
+                              <div className="user-profile-invite-code">{invite.code}</div>
+                              {invite.receiver && (
+                                <div className="user-profile-invite-email">{invite.receiver.email}</div>
+                              )}
+                              <div className="user-profile-invite-expiry">
+                                {t('family.expiresOn')}: {new Date(invite.expiresAt).toLocaleDateString()}
+                              </div>
+                            </div>
+                            <button
+                              onClick={() => navigator.clipboard.writeText(invite.code)}
+                              className="user-profile-button user-profile-button-secondary user-profile-button-sm"
+                              title={t('family.copyInviteCode')}
+                            >
+                              {t('family.copy')}
+                            </button>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </>
+              )}
+            </section>
           )}
         </div>
       </div>

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -17,7 +17,8 @@
     "back": "Back",
     "continue": "Continue",
     "close": "Close",
-    "saving": "Saving..."
+    "saving": "Saving...",
+    "optional": "optional"
   },
   "auth": {
     "login": "Login",
@@ -127,9 +128,39 @@
     "respondedOn": "Responded on",
     "joinRequestApproved": "Join request approved successfully",
     "joinRequestRejected": "Join request rejected",
-    "failedToRespondToRequest": "Failed to respond to join request"
+    "failedToRespondToRequest": "Failed to respond to join request",
+    "updateProfile": "Update Profile"
   },
   "family": {
+    "members": "Family Members",
+    "inviteEmail": "Email Address",
+    "inviteEmailPlaceholder": "Enter email address (optional)",
+    "expiresIn": "Expires In",
+    "expiry": {
+      "1day": "1 Day",
+      "3days": "3 Days", 
+      "7days": "7 Days",
+      "14days": "14 Days",
+      "30days": "30 Days"
+    },
+    "generateInvite": "Generate Invite",
+    "generatingInvite": "Generating...",
+    "inviteCreated": "Invite created successfully",
+    "inviteError": "Failed to create invite",
+    "activeInvites": "Active Invites",
+    "expiresOn": "Expires on",
+    "copy": "Copy",
+    "copyInviteCode": "Copy invite code",
+    "joinRequests": "Join Requests",
+    "approve": "Approve",
+    "reject": "Reject",
+    "requestApproved": "Request approved successfully",
+    "requestRejected": "Request rejected successfully", 
+    "requestError": "Failed to process request",
+    "role": {
+      "admin": "Admin",
+      "member": "Member"
+    },
     "onboarding": {
       "title": "Welcome to Family Board!",
       "subtitle": "To get started, you need to either create a new family or join an existing one.",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -17,7 +17,8 @@
     "back": "Retour",
     "continue": "Continuer",
     "close": "Fermer",
-    "saving": "Enregistrement..."
+    "saving": "Enregistrement...",
+    "optional": "optionnel"
   },
   "auth": {
     "login": "Se Connecter",
@@ -126,9 +127,39 @@
     "respondedOn": "Répondu le",
     "joinRequestApproved": "Demande d'adhésion approuvée avec succès",
     "joinRequestRejected": "Demande d'adhésion rejetée",
-    "failedToRespondToRequest": "Échec de la réponse à la demande d'adhésion"
+    "failedToRespondToRequest": "Échec de la réponse à la demande d'adhésion",
+    "updateProfile": "Mettre à jour le profil"
   },
   "family": {
+    "members": "Membres de la famille",
+    "inviteEmail": "Adresse e-mail",
+    "inviteEmailPlaceholder": "Entrez l'adresse e-mail (optionnel)",
+    "expiresIn": "Expire dans",
+    "expiry": {
+      "1day": "1 jour",
+      "3days": "3 jours", 
+      "7days": "7 jours",
+      "14days": "14 jours",
+      "30days": "30 jours"
+    },
+    "generateInvite": "Générer une invitation",
+    "generatingInvite": "Génération...",
+    "inviteCreated": "Invitation créée avec succès",
+    "inviteError": "Échec de la création de l'invitation",
+    "activeInvites": "Invitations actives",
+    "expiresOn": "Expire le",
+    "copy": "Copier",
+    "copyInviteCode": "Copier le code d'invitation",
+    "joinRequests": "Demandes d'adhésion",
+    "approve": "Approuver",
+    "reject": "Rejeter",
+    "requestApproved": "Demande approuvée avec succès",
+    "requestRejected": "Demande rejetée avec succès", 
+    "requestError": "Échec du traitement de la demande",
+    "role": {
+      "admin": "Administrateur",
+      "member": "Membre"
+    },
     "onboarding": {
       "title": "Bienvenue sur Tableau de Famille !",
       "subtitle": "Pour commencer, vous devez créer une nouvelle famille ou rejoindre une famille existante.",


### PR DESCRIPTION
Complete revamp of UserProfile dialog to improve UX by removing confusing nested tabs and fixing critical bug where non-admin family members couldn't see other family members.

Key changes:
- Removed all tabs in favor of clear sections
- Increased modal width from 500px to 900px  
- Added click-outside-to-close functionality
- Fixed family members visibility for non-admin users
- Added comprehensive test coverage
- Updated responsive design and translations

Bug fix: Non-admin family members can now see other family members (was only loading for admins before).