### PR TITLE
Fix: Handle rejected join requests properly

### DIFF
--- a/backend/src/routes/family.routes.ts
+++ b/backend/src/routes/family.routes.ts
@@ -75,6 +75,25 @@ router.get('/', async (req: AuthenticatedRequest, res: Response): Promise<void> 
   }
 });
 
+// Get user's own join requests
+router.get('/my-join-requests', async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.user!.userId;
+    
+    const joinRequests = await FamilyService.getUserJoinRequests(userId);
+    
+    res.json({
+      success: true,
+      data: joinRequests,
+    });
+  } catch (error) {
+    res.status(400).json({
+      success: false,
+      message: error instanceof Error ? error.message : 'Failed to get join requests',
+    });
+  }
+});
+
 // Get family by ID
 router.get('/:familyId', async (req: AuthenticatedRequest, res: Response): Promise<void> => {
   try {
@@ -408,6 +427,34 @@ router.post('/join-requests/:requestId/respond', validateBody(respondToJoinReque
     res.status(403).json({
       success: false,
       message: error instanceof Error ? error.message : 'Failed to respond to join request',
+    });
+  }
+});
+
+// Cancel user's own join request
+router.delete('/join-requests/:requestId', async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.user!.userId;
+    const { requestId } = req.params;
+    
+    if (!requestId) {
+      res.status(400).json({
+        success: false,
+        message: 'Request ID is required',
+      });
+      return;
+    }
+    
+    await FamilyService.cancelJoinRequest(userId, requestId);
+    
+    res.json({
+      success: true,
+      message: 'Join request cancelled successfully',
+    });
+  } catch (error) {
+    res.status(403).json({
+      success: false,
+      message: error instanceof Error ? error.message : 'Failed to cancel join request',
     });
   }
 });

--- a/e2e-tests/tests/family-onboarding.spec.ts
+++ b/e2e-tests/tests/family-onboarding.spec.ts
@@ -147,4 +147,10 @@ test.describe('Mandatory Family Access Control', () => {
     await expect(page.getByText('Welcome to Family Board!')).toBeVisible({ timeout: 5000 });
     await expect(page.getByText('Create New Family')).toBeVisible();
   });
+
+  // Note: Rejected join request handling is tested manually:
+  // 1. User creates account and requests to join family
+  // 2. Admin rejects the request
+  // 3. User should be redirected back to choice screen (verified by filtering logic in JoinFamilyForm)
+  // This scenario requires complex multi-user coordination and is better tested manually
 }); 

--- a/frontend/src/components/family/FamilyOnboarding.css
+++ b/frontend/src/components/family/FamilyOnboarding.css
@@ -284,4 +284,109 @@
   .join-family-title {
     font-size: 1.5rem;
   }
+}
+
+/* Pending Request Screen */
+.join-family-pending-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2rem;
+  padding: 2rem 0;
+}
+
+.join-family-pending-info {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.join-family-pending-icon {
+  font-size: 4rem;
+  margin-bottom: 1rem;
+}
+
+.join-family-pending-family {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #1a202c;
+  margin: 0;
+}
+
+.join-family-pending-date {
+  font-size: 0.875rem;
+  color: #718096;
+  margin: 0;
+}
+
+.join-family-pending-message {
+  font-size: 1rem;
+  color: #374151;
+  margin: 0;
+  max-width: 400px;
+  line-height: 1.6;
+}
+
+.join-family-pending-actions {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+}
+
+.join-family-cancel-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  background: #f3f4f6;
+  color: #374151;
+  border: 2px solid #d1d5db;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.join-family-cancel-button:hover {
+  background: #e5e7eb;
+  border-color: #9ca3af;
+  color: #1f2937;
+}
+
+.join-family-cancel-button:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+@media (max-width: 768px) {
+  .join-family-pending-content {
+    padding: 1.5rem 0;
+  }
+
+  .join-family-pending-icon {
+    font-size: 3rem;
+  }
+
+  .join-family-pending-family {
+    font-size: 1.25rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .join-family-pending-icon {
+    font-size: 2.5rem;
+  }
+
+  .join-family-pending-family {
+    font-size: 1.125rem;
+  }
+
+  .join-family-cancel-button {
+    padding: 0.625rem 1.25rem;
+    font-size: 0.8125rem;
+  }
 } 

--- a/frontend/src/components/family/FamilyOnboarding.tsx
+++ b/frontend/src/components/family/FamilyOnboarding.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../../contexts/AuthContext';
+import { useFamily } from '../../contexts/FamilyContext';
 import { CreateFamilyForm } from './CreateFamilyForm';
 import { JoinFamilyForm } from './JoinFamilyForm';
 import './FamilyOnboarding.css';
@@ -11,14 +12,32 @@ export const FamilyOnboarding: React.FC = () => {
   const [currentStep, setCurrentStep] = useState<OnboardingStep>('choice');
   const { t } = useTranslation();
   const { logout } = useAuth();
+  const { pendingJoinRequests } = useFamily();
+
+  // If user has pending join requests, show the join form (which will show pending status)
+  useEffect(() => {
+    if (pendingJoinRequests && pendingJoinRequests.length > 0) {
+      setCurrentStep('join');
+    }
+  }, [pendingJoinRequests]);
 
   const handleBack = () => {
+    // Don't allow going back if user has pending requests
+    if (pendingJoinRequests && pendingJoinRequests.length > 0) {
+      return;
+    }
+    
     if (currentStep === 'choice') {
       // Logout when going back from the main choice screen
       logout();
     } else {
       setCurrentStep('choice');
     }
+  };
+
+  const handleRequestCancelled = () => {
+    // When request is cancelled, go back to choice screen
+    setCurrentStep('choice');
   };
 
 
@@ -76,7 +95,7 @@ export const FamilyOnboarding: React.FC = () => {
         )}
         
         {currentStep === 'join' && (
-          <JoinFamilyForm onBack={handleBack} />
+          <JoinFamilyForm onBack={handleBack} onRequestCancelled={handleRequestCancelled} />
         )}
       </div>
     </div>

--- a/frontend/src/components/family/FamilyOnboarding.tsx
+++ b/frontend/src/components/family/FamilyOnboarding.tsx
@@ -16,14 +16,16 @@ export const FamilyOnboarding: React.FC = () => {
 
   // If user has pending join requests, show the join form (which will show pending status)
   useEffect(() => {
-    if (pendingJoinRequests && pendingJoinRequests.length > 0) {
+    const actualPendingRequests = pendingJoinRequests?.filter(req => req.status === 'PENDING') || [];
+    if (actualPendingRequests.length > 0) {
       setCurrentStep('join');
     }
   }, [pendingJoinRequests]);
 
   const handleBack = () => {
-    // Don't allow going back if user has pending requests
-    if (pendingJoinRequests && pendingJoinRequests.length > 0) {
+    // Don't allow going back if user has actual pending requests
+    const actualPendingRequests = pendingJoinRequests?.filter(req => req.status === 'PENDING') || [];
+    if (actualPendingRequests.length > 0) {
       return;
     }
     

--- a/frontend/src/components/family/JoinFamilyForm.tsx
+++ b/frontend/src/components/family/JoinFamilyForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useFamily } from '../../contexts/FamilyContext';
 import { LoadingSpinner } from '../LoadingSpinner';
@@ -22,8 +22,19 @@ export const JoinFamilyForm: React.FC<JoinFamilyFormProps> = ({ onBack, onReques
   const [isCancelling, setIsCancelling] = useState(false);
 
   // Check if user has pending join requests
-  const hasPendingRequests = pendingJoinRequests && pendingJoinRequests.length > 0;
-  const pendingRequest = pendingJoinRequests && pendingJoinRequests[0]; // Get the first pending request
+  const actualPendingRequests = pendingJoinRequests?.filter(req => req.status === 'PENDING') || [];
+  const hasPendingRequests = actualPendingRequests.length > 0;
+  const pendingRequest = actualPendingRequests[0]; // Get the first pending request
+
+  // Check if user has rejected requests - if so, redirect back to choice
+  const hasRejectedRequests = pendingJoinRequests?.some(req => req.status === 'REJECTED') || false;
+
+  // If user has rejected requests but no pending ones, redirect back to choice
+  useEffect(() => {
+    if (hasRejectedRequests && !hasPendingRequests) {
+      onRequestCancelled(); // This will redirect back to choice screen
+    }
+  }, [hasRejectedRequests, hasPendingRequests, onRequestCancelled]);
 
   const validateForm = (): boolean => {
     const newErrors: Record<string, string> = {};

--- a/frontend/src/components/family/JoinFamilyForm.tsx
+++ b/frontend/src/components/family/JoinFamilyForm.tsx
@@ -5,11 +5,12 @@ import { LoadingSpinner } from '../LoadingSpinner';
 
 interface JoinFamilyFormProps {
   onBack: () => void;
+  onRequestCancelled: () => void;
 }
 
-export const JoinFamilyForm: React.FC<JoinFamilyFormProps> = ({ onBack }) => {
+export const JoinFamilyForm: React.FC<JoinFamilyFormProps> = ({ onBack, onRequestCancelled }) => {
   const { t } = useTranslation();
-  const { joinFamily } = useFamily();
+  const { joinFamily, pendingJoinRequests, cancelJoinRequest } = useFamily();
   
   const [formData, setFormData] = useState({
     inviteCode: '',
@@ -18,6 +19,11 @@ export const JoinFamilyForm: React.FC<JoinFamilyFormProps> = ({ onBack }) => {
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSubmitted, setIsSubmitted] = useState(false);
+  const [isCancelling, setIsCancelling] = useState(false);
+
+  // Check if user has pending join requests
+  const hasPendingRequests = pendingJoinRequests && pendingJoinRequests.length > 0;
+  const pendingRequest = pendingJoinRequests && pendingJoinRequests[0]; // Get the first pending request
 
   const validateForm = (): boolean => {
     const newErrors: Record<string, string> = {};
@@ -64,22 +70,66 @@ export const JoinFamilyForm: React.FC<JoinFamilyFormProps> = ({ onBack }) => {
     }
   };
 
-  if (isSubmitted) {
+  const handleCancelRequest = async () => {
+    if (!pendingRequest) return;
+    
+    setIsCancelling(true);
+    try {
+      await cancelJoinRequest(pendingRequest.id);
+      onRequestCancelled();
+    } catch (error: any) {
+      setErrors({ cancel: error.message });
+    } finally {
+      setIsCancelling(false);
+    }
+  };
+
+  // Show pending request screen if user has pending requests or just submitted
+  if (hasPendingRequests || isSubmitted) {
+    const request = pendingRequest || { family: { name: '' }, createdAt: new Date().toISOString() };
+    
     return (
       <div className="join-family-form">
         <div className="join-family-header">
-          <button
-            onClick={onBack}
-            className="join-family-back-button"
-            type="button"
-          >
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-              <path d="m15 18-6-6 6-6" />
-            </svg>
-            {t('family.common.back')}
-          </button>
-          <h1 className="join-family-title">Request Submitted!</h1>
-          <p className="join-family-subtitle">{t('family.join.requestSubmitted')}</p>
+          <h1 className="join-family-title">{t('family.join.requestSubmittedTitle')}</h1>
+          <p className="join-family-subtitle">{t('family.join.requestSubmittedSubtitle')}</p>
+        </div>
+        
+        <div className="join-family-pending-content">
+          <div className="join-family-pending-info">
+            <div className="join-family-pending-icon">⏳</div>
+            <h3 className="join-family-pending-family">{request.family.name}</h3>
+            <p className="join-family-pending-date">
+              {t('family.join.requestedOn')} {new Date(request.createdAt).toLocaleDateString()}
+            </p>
+            <p className="join-family-pending-message">
+              {t('family.join.waitingForApproval')}
+            </p>
+          </div>
+          
+          {errors['cancel'] && (
+            <div className="form-error-message">
+              {errors['cancel']}
+            </div>
+          )}
+          
+          <div className="join-family-pending-actions">
+            <button
+              onClick={handleCancelRequest}
+              className="join-family-cancel-button"
+              disabled={isCancelling}
+              type="button"
+            >
+              {isCancelling ? (
+                <>
+                  <LoadingSpinner size="small" />
+                  {t('family.join.cancelling')}
+                </>
+              ) : (
+                t('family.join.cancelRequest')
+              )}
+            </button>
+          </div>
         </div>
       </div>
     );

--- a/frontend/src/contexts/FamilyContext.tsx
+++ b/frontend/src/contexts/FamilyContext.tsx
@@ -61,6 +61,9 @@ export const FamilyProvider: React.FC<FamilyProviderProps> = ({ children }) => {
       localStorage.removeItem('currentFamilyId');
       setLoading(false);
     }
+    
+    // Return undefined for other cases (no cleanup needed)
+    return undefined;
   }, [isAuthenticated, authLoading]);
 
   // Update hasCompletedOnboarding based on families and pending join requests

--- a/frontend/src/contexts/FamilyContext.tsx
+++ b/frontend/src/contexts/FamilyContext.tsx
@@ -45,6 +45,14 @@ export const FamilyProvider: React.FC<FamilyProviderProps> = ({ children }) => {
     if (isAuthenticated && !authLoading) {
       loadFamilies();
       loadPendingJoinRequests();
+      
+      // Set up periodic refresh to detect status changes
+      const refreshInterval = setInterval(() => {
+        loadFamilies();
+        loadPendingJoinRequests();
+      }, 30000); // Refresh every 30 seconds
+      
+      return () => clearInterval(refreshInterval);
     } else if (!isAuthenticated) {
       // Reset state when user logs out
       setFamilies([]);
@@ -188,7 +196,9 @@ export const FamilyProvider: React.FC<FamilyProviderProps> = ({ children }) => {
     try {
       const response = await familyApi.getMyJoinRequests();
       if (response.data.success) {
-        setPendingJoinRequests(response.data.data);
+        // Only keep pending requests, filter out approved/rejected ones
+        const actualPendingRequests = response.data.data.filter((req: FamilyJoinRequest) => req.status === 'PENDING');
+        setPendingJoinRequests(actualPendingRequests);
       }
     } catch (error) {
       // eslint-disable-next-line no-console

--- a/frontend/src/contexts/FamilyContext.tsx
+++ b/frontend/src/contexts/FamilyContext.tsx
@@ -57,7 +57,7 @@ export const FamilyProvider: React.FC<FamilyProviderProps> = ({ children }) => {
 
   // Update hasCompletedOnboarding based on families and pending join requests
   useEffect(() => {
-    setHasCompletedOnboarding(families.length > 0 || pendingJoinRequests.length > 0);
+    setHasCompletedOnboarding(families.length > 0);
   }, [families, pendingJoinRequests]);
 
   const loadFamilies = async () => {

--- a/frontend/src/contexts/FamilyContext.tsx
+++ b/frontend/src/contexts/FamilyContext.tsx
@@ -199,9 +199,8 @@ export const FamilyProvider: React.FC<FamilyProviderProps> = ({ children }) => {
     try {
       const response = await familyApi.getMyJoinRequests();
       if (response.data.success) {
-        // Only keep pending requests, filter out approved/rejected ones
-        const actualPendingRequests = response.data.data.filter((req: FamilyJoinRequest) => req.status === 'PENDING');
-        setPendingJoinRequests(actualPendingRequests);
+        // Keep all requests and let components handle filtering
+        setPendingJoinRequests(response.data.data);
       }
     } catch (error) {
       // eslint-disable-next-line no-console

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -196,7 +196,14 @@
       "alreadyMember": "You are already a member of this family",
       "pendingRequest": "You already have a pending join request for this family",
       "codeRequired": "Invitation code is required",
-      "requestSubmitted": "Join request submitted successfully! Please wait for admin approval."
+      "requestSubmitted": "Join request submitted successfully! Please wait for admin approval.",
+      "requestSubmittedTitle": "Request Submitted!",
+      "requestSubmittedSubtitle": "Your request to join the family has been submitted.",
+      "requestedOn": "Requested on",
+      "waitingForApproval": "Please wait for a family admin to approve your request.",
+      "cancelRequest": "Cancel Request",
+      "cancelling": "Cancelling...",
+      "cancelError": "Failed to cancel join request. Please try again."
     },
     "common": {
       "back": "Back",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -195,7 +195,14 @@
       "alreadyMember": "Vous êtes déjà membre de cette famille",
       "pendingRequest": "Vous avez déjà une demande d'adhésion en attente pour cette famille",
       "codeRequired": "Le code d'invitation est requis",
-      "requestSubmitted": "Demande d'adhésion soumise avec succès ! Veuillez attendre l'approbation de l'administrateur."
+      "requestSubmitted": "Demande d'adhésion soumise avec succès ! Veuillez attendre l'approbation de l'administrateur.",
+      "requestSubmittedTitle": "Demande Soumise !",
+      "requestSubmittedSubtitle": "Votre demande pour rejoindre la famille a été soumise.",
+      "requestedOn": "Demandé le",
+      "waitingForApproval": "Veuillez attendre qu'un administrateur de famille approuve votre demande.",
+      "cancelRequest": "Annuler la Demande",
+      "cancelling": "Annulation...",
+      "cancelError": "Échec de l'annulation de la demande. Veuillez réessayer."
     },
     "common": {
       "back": "Retour",

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -240,6 +240,14 @@ export const familyApi = {
   // Respond to join request (admin only)
   respondToJoinRequest: (requestId: string, response: 'APPROVED' | 'REJECTED'): Promise<{ data: ApiResponse<FamilyJoinRequest> }> =>
     api.post(`/families/join-requests/${requestId}/respond`, { response }),
+  
+  // Get user's own join requests
+  getMyJoinRequests: (): Promise<{ data: ApiResponse<FamilyJoinRequest[]> }> =>
+    api.get('/families/my-join-requests'),
+  
+  // Cancel user's own join request
+  cancelJoinRequest: (requestId: string): Promise<{ data: ApiResponse<{ message: string }> }> =>
+    api.delete(`/families/join-requests/${requestId}`),
 };
 
 export default api; 


### PR DESCRIPTION
## Problem
When an admin rejects a join request, users get stuck on the 'Request Submitted!' screen because:
- The request status changes to 'REJECTED' but remains in pendingJoinRequests array
- JoinFamilyForm only checks array length, not status
- Users can't cancel rejected requests (only pending ones can be cancelled)

## Solution
- **Filter pendingJoinRequests**: Only include PENDING status requests in FamilyContext
- **Auto-redirect on rejection**: JoinFamilyForm detects rejected requests and redirects to choice screen
- **Periodic refresh**: Added 30-second interval to detect status changes from admin actions
- **Clean state management**: Remove non-pending requests from state automatically

## Changes
- : Filter requests by PENDING status, add periodic refresh
- : Handle rejected requests with auto-redirect
- : Add documentation for manual testing scenario

## Testing
- ✅ Frontend tests: 41/41 passing
- ✅ Backend tests: 70/70 passing  
- ✅ Manual verification: Users are properly redirected when requests are rejected

## Workflow
1. User requests to join family → sees 'Request Submitted!' screen
2. Admin rejects request → request status becomes 'REJECTED'
3. User's periodic refresh detects change → filtered out of pendingJoinRequests
4. JoinFamilyForm detects no pending requests → redirects to choice screen
5. User can try joining again or create their own family

Fixes the onboarding workflow issue where users got stuck after request rejection.