### PR TITLE
fix: restore proper spacing between section icons and titles in profile dialog

### DIFF
--- a/frontend/src/components/UserProfile.css
+++ b/frontend/src/components/UserProfile.css
@@ -130,6 +130,7 @@
   align-items: center;
   justify-content: space-between;
   margin-bottom: 1rem;
+  gap: 1rem;
 }
 
 .user-profile-section-header h3 {
@@ -183,6 +184,14 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
+}
+
+.user-profile-subsection-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+  gap: 1rem;
 }
 
 .user-profile-count-badge {


### PR DESCRIPTION
## 🎯 Fix Profile Section Spacing Issue

This PR fixes the spacing issue between section icons and their titles in the profile dialog that was introduced in the virtual members PR.

### 🐛 **Problem**
- Section icons and titles were too close together, making the profile dialog look cramped
- Missing CSS class for subsection headers causing inconsistent styling
- Reduced readability and poor visual hierarchy

### ✅ **Solution**
- **Added gap spacing**: Added `gap: 1rem` to `.user-profile-section-header` for proper spacing between icons and titles
- **Added missing CSS class**: Created `.user-profile-subsection-header` with consistent styling
- **Improved visual hierarchy**: Restored proper spacing for better readability

### 📝 **Changes**
- `frontend/src/components/UserProfile.css`: Added gap properties to section and subsection headers

### 🎨 **Visual Impact**
- ✅ Section icons and titles now have proper 1rem spacing
- ✅ Subsection headers are consistently styled  
- ✅ Better visual hierarchy and readability
- ✅ Consistent spacing across all profile dialog sections

### 🧪 **Testing**
- Minimal CSS-only changes focused on spacing
- No functional changes, only visual improvements
- Safe to merge without extensive testing

This is a quick fix for the spacing regression introduced in PR #22.