### PR TITLE
feat: implement WeekTemplate backend functionality

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -30,19 +30,20 @@ model User {
 }
 
 model Family {
-  id           String              @id @default(cuid())
-  name         String
-  description  String?
-  avatarUrl    String?             @map("avatar_url")
-  createdAt    DateTime            @default(now()) @map("created_at")
-  updatedAt    DateTime            @updatedAt @map("updated_at")
-  creatorId    String              @map("creator_id")
-  creator      User                @relation("FamilyCreator", fields: [creatorId], references: [id], onDelete: Cascade)
-  invites      FamilyInvite[]
-  joinRequests FamilyJoinRequest[]
-  members      FamilyMember[]
-  tasks        Task[]
-  dayTemplates DayTemplate[]
+  id            String              @id @default(cuid())
+  name          String
+  description   String?
+  avatarUrl     String?             @map("avatar_url")
+  createdAt     DateTime            @default(now()) @map("created_at")
+  updatedAt     DateTime            @updatedAt @map("updated_at")
+  creatorId     String              @map("creator_id")
+  creator       User                @relation("FamilyCreator", fields: [creatorId], references: [id], onDelete: Cascade)
+  invites       FamilyInvite[]
+  joinRequests  FamilyJoinRequest[]
+  members       FamilyMember[]
+  tasks         Task[]
+  dayTemplates  DayTemplate[]
+  weekTemplates WeekTemplate[]
 
   @@map("families")
 }
@@ -142,15 +143,16 @@ model TaskAssignment {
 // DayTemplate represents a reusable template for scheduling tasks
 // Examples: "Weekday", "Weekend", "School Day", "Holiday"
 model DayTemplate {
-  id          String            @id @default(cuid())
-  name        String            // Template name (e.g., "Weekday", "Weekend")
-  description String?           // Optional description
-  isActive    Boolean           @default(true) // Whether this template can be used
-  createdAt   DateTime          @default(now()) @map("created_at")
-  updatedAt   DateTime          @updatedAt @map("updated_at")
-  familyId    String            @map("family_id")
-  family      Family            @relation(fields: [familyId], references: [id], onDelete: Cascade)
-  items       DayTemplateItem[] // Tasks included in this template
+  id              String             @id @default(cuid())
+  name            String             // Template name (e.g., "Weekday", "Weekend")
+  description     String?            // Optional description
+  isActive        Boolean            @default(true) // Whether this template can be used
+  createdAt       DateTime           @default(now()) @map("created_at")
+  updatedAt       DateTime           @updatedAt @map("updated_at")
+  familyId        String             @map("family_id")
+  family          Family             @relation(fields: [familyId], references: [id], onDelete: Cascade)
+  items           DayTemplateItem[]  // Tasks included in this template
+  weekTemplateDays WeekTemplateDay[] // Week templates that use this day template
 
   @@unique([familyId, name]) // Unique template names per family
   @@map("day_templates")
@@ -175,6 +177,41 @@ model DayTemplateItem {
   // Ensure one template item per member per task per template (allow multiple unassigned)
   @@unique([dayTemplateId, memberId, taskId])
   @@map("day_template_items")
+}
+
+// WeekTemplate represents a reusable template for scheduling a full week
+// Contains 7 DayTemplates, one for each day of the week (Monday through Sunday)
+// Examples: "Standard Work Week", "School Week", "Vacation Week"
+model WeekTemplate {
+  id          String             @id @default(cuid())
+  name        String             // Template name (e.g., "Standard Work Week", "School Week")
+  description String?            // Optional description
+  isActive    Boolean            @default(true) // Whether this template can be used
+  createdAt   DateTime           @default(now()) @map("created_at")
+  updatedAt   DateTime           @updatedAt @map("updated_at")
+  familyId    String             @map("family_id")
+  family      Family             @relation(fields: [familyId], references: [id], onDelete: Cascade)
+  days        WeekTemplateDay[]  // Day templates for each day of the week
+
+  @@unique([familyId, name]) // Unique template names per family
+  @@map("week_templates")
+}
+
+// WeekTemplateDay represents a day template assignment within a week template
+// Links a specific day of the week to a DayTemplate
+model WeekTemplateDay {
+  id             String       @id @default(cuid())
+  dayOfWeek      Int          // 0 = Sunday, 1 = Monday, ..., 6 = Saturday (ISO 8601 standard)
+  dayTemplateId  String       @map("day_template_id")
+  createdAt      DateTime     @default(now()) @map("created_at")
+  updatedAt      DateTime     @updatedAt @map("updated_at")
+  weekTemplateId String       @map("week_template_id")
+  weekTemplate   WeekTemplate @relation(fields: [weekTemplateId], references: [id], onDelete: Cascade)
+  dayTemplate    DayTemplate  @relation(fields: [dayTemplateId], references: [id], onDelete: Cascade)
+
+  // Ensure one day template per day of week per week template
+  @@unique([weekTemplateId, dayOfWeek])
+  @@map("week_template_days")
 }
 
 enum FamilyMemberRole {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -10,6 +10,7 @@ import familyRoutes from './routes/family.routes';
 import taskRoutes from './routes/task.routes';
 import taskAssignmentRoutes from './routes/task-assignment.routes';
 import dayTemplateRoutes from './routes/day-template.routes';
+import weekTemplateRoutes from './routes/week-template.routes';
 import { errorHandler } from './middleware/error.middleware';
 import { initializeWebSocket } from './services/websocket.service';
 
@@ -43,6 +44,7 @@ async function startServer(): Promise<void> {
     app.use('/api/tasks', taskRoutes);
     app.use('/api', taskAssignmentRoutes);
     app.use('/api/families', dayTemplateRoutes);
+    app.use('/api/families', weekTemplateRoutes);
 
     // Error handling
     app.use(errorHandler);

--- a/backend/src/routes/week-template.routes.ts
+++ b/backend/src/routes/week-template.routes.ts
@@ -1,0 +1,1040 @@
+import { Router, Response } from 'express';
+import { z } from 'zod';
+import { weekTemplateService } from '../services/week-template.service';
+import { authenticateToken, AuthenticatedRequest } from '../middleware/auth.middleware';
+import {
+  WeekTemplateResponseDto,
+  WeekTemplateDayResponseDto,
+  ApplyWeekTemplateDto,
+} from '../types/task.types';
+import { PrismaClient } from '@prisma/client';
+
+const router = Router();
+const prisma = new PrismaClient();
+
+// Apply auth middleware to all routes
+router.use(authenticateToken);
+
+// Helper method to check if user is a family member
+async function checkFamilyMembership(userId: string, familyId: string): Promise<{ role: string }> {
+  const membership = await prisma.familyMember.findUnique({
+    where: {
+      userId_familyId: {
+        userId,
+        familyId,
+      },
+    },
+  });
+
+  if (!membership) {
+    throw new Error('Access denied: You are not a member of this family');
+  }
+
+  return { role: membership.role };
+}
+
+// Helper method to check if user is family admin
+async function checkFamilyAdmin(userId: string, familyId: string): Promise<void> {
+  const membership = await checkFamilyMembership(userId, familyId);
+  
+  if (membership.role !== 'ADMIN') {
+    throw new Error('Access denied: Only family admins can perform this action');
+  }
+}
+
+// ==================== WEEK TEMPLATE CRUD ====================
+
+/**
+ * POST /api/families/:familyId/week-templates
+ * Create a new week template
+ */
+router.post('/:familyId/week-templates', async (req: AuthenticatedRequest, res: Response) => {
+  console.log('=== WEEK TEMPLATE CREATE REQUEST ===');
+  console.log('URL params:', req.params);
+  console.log('Request body:', req.body);
+  console.log('User from token:', req.user);
+  
+  try {
+    const { familyId } = req.params;
+    const userId = req.user!.userId;
+    
+    console.log('Extracted familyId:', familyId);
+    console.log('Extracted userId:', userId);
+    
+    if (!familyId) {
+      console.log('ERROR: Missing familyId');
+      return res.status(400).json({ error: 'Family ID is required' });
+    }
+
+    console.log('Checking family admin permissions...');
+    // Check if user is admin of the family
+    await checkFamilyAdmin(userId, familyId);
+    console.log('Admin check passed!');
+
+    console.log('Creating week template with service...');
+    const template = await weekTemplateService.createWeekTemplate(req.body, familyId);
+    console.log('Week template created successfully:', template.id);
+    
+    const response: WeekTemplateResponseDto = {
+      id: template.id,
+      name: template.name,
+      description: template.description,
+      isActive: template.isActive,
+      createdAt: template.createdAt.toISOString(),
+      updatedAt: template.updatedAt.toISOString(),
+      familyId: template.familyId,
+      days: template.days.map((day): WeekTemplateDayResponseDto => ({
+        id: day.id,
+        dayOfWeek: day.dayOfWeek,
+        dayTemplateId: day.dayTemplateId,
+        createdAt: day.createdAt.toISOString(),
+        updatedAt: day.updatedAt.toISOString(),
+        weekTemplateId: day.weekTemplateId,
+        dayTemplate: {
+          id: day.dayTemplate.id,
+          name: day.dayTemplate.name,
+          description: day.dayTemplate.description,
+          isActive: day.dayTemplate.isActive,
+          createdAt: day.dayTemplate.createdAt.toISOString(),
+          updatedAt: day.dayTemplate.updatedAt.toISOString(),
+          familyId: day.dayTemplate.familyId,
+          items: day.dayTemplate.items.map((item) => ({
+            id: item.id,
+            memberId: item.memberId,
+            taskId: item.taskId,
+            overrideTime: item.overrideTime,
+            overrideDuration: item.overrideDuration,
+            sortOrder: item.sortOrder,
+            createdAt: item.createdAt.toISOString(),
+            updatedAt: item.updatedAt.toISOString(),
+            dayTemplateId: item.dayTemplateId,
+            member: item.member,
+            task: item.task,
+          })),
+        },
+      })),
+    };
+
+    return res.status(201).json(response);
+  } catch (error) {
+    console.log('=== WEEK TEMPLATE CREATE ERROR ===');
+    console.log('Error type:', error?.constructor?.name);
+    console.log('Error message:', (error as any)?.message);
+    console.log('Full error:', error);
+    
+    if (error instanceof z.ZodError) {
+      console.log('Zod validation error:', error.errors);
+      return res.status(400).json({
+        error: 'Validation failed',
+        details: error.errors,
+      });
+    }
+    
+    if (error instanceof Error) {
+      if (error.message.includes('Access denied')) {
+        console.log('Access denied error');
+        return res.status(403).json({ error: error.message });
+      }
+      if (error.message.includes('already exists')) {
+        console.log('Duplicate name error');
+        return res.status(409).json({ error: error.message });
+      }
+    }
+
+    console.error('Unexpected error creating week template:', error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
+ * GET /api/families/:familyId/week-templates
+ * Get all week templates for a family with filtering and pagination
+ */
+router.get('/:familyId/week-templates', async (req: AuthenticatedRequest, res: Response) => {
+  console.log('=== WEEK TEMPLATE GET REQUEST ===');
+  console.log('URL params:', req.params);
+  console.log('Query params:', req.query);
+  console.log('User from token:', req.user);
+  
+  try {
+    const { familyId } = req.params;
+    const userId = req.user!.userId;
+    
+    console.log('Extracted familyId:', familyId);
+    console.log('Extracted userId:', userId);
+    
+    if (!familyId) {
+      console.log('ERROR: Missing familyId');
+      return res.status(400).json({ error: 'Family ID is required' });
+    }
+
+    console.log('Checking family membership...');
+    // Check if user is a member of the family
+    await checkFamilyMembership(userId, familyId);
+    console.log('Family membership check passed!');
+
+    const {
+      isActive,
+      search,
+      page = '1',
+      limit = '50',
+    } = req.query;
+
+    const queryParams: any = {
+      page: parseInt(page as string, 10),
+      limit: parseInt(limit as string, 10),
+    };
+
+    if (isActive === 'true') {
+      queryParams.isActive = true;
+    } else if (isActive === 'false') {
+      queryParams.isActive = false;
+    }
+
+    if (search) {
+      queryParams.search = search as string;
+    }
+
+    console.log('Calling weekTemplateService.getWeekTemplates with params:', queryParams);
+    const result = await weekTemplateService.getWeekTemplates(familyId, queryParams);
+    console.log('Service call successful, got result:', { 
+      templatesCount: result.templates.length,
+      total: result.total,
+      page: result.page,
+      limit: result.limit
+    });
+    
+    const response = {
+      templates: result.templates.map((template): WeekTemplateResponseDto => ({
+        id: template.id,
+        name: template.name,
+        description: template.description,
+        isActive: template.isActive,
+        createdAt: template.createdAt.toISOString(),
+        updatedAt: template.updatedAt.toISOString(),
+        familyId: template.familyId,
+        days: template.days.map((day): WeekTemplateDayResponseDto => ({
+          id: day.id,
+          dayOfWeek: day.dayOfWeek,
+          dayTemplateId: day.dayTemplateId,
+          createdAt: day.createdAt.toISOString(),
+          updatedAt: day.updatedAt.toISOString(),
+          weekTemplateId: day.weekTemplateId,
+          dayTemplate: {
+            id: day.dayTemplate.id,
+            name: day.dayTemplate.name,
+            description: day.dayTemplate.description,
+            isActive: day.dayTemplate.isActive,
+            createdAt: day.dayTemplate.createdAt.toISOString(),
+            updatedAt: day.dayTemplate.updatedAt.toISOString(),
+            familyId: day.dayTemplate.familyId,
+            items: day.dayTemplate.items.map((item) => ({
+              id: item.id,
+              memberId: item.memberId,
+              taskId: item.taskId,
+              overrideTime: item.overrideTime,
+              overrideDuration: item.overrideDuration,
+              sortOrder: item.sortOrder,
+              createdAt: item.createdAt.toISOString(),
+              updatedAt: item.updatedAt.toISOString(),
+              dayTemplateId: item.dayTemplateId,
+              member: item.member,
+              task: item.task,
+            })),
+          },
+        })),
+      })),
+      pagination: {
+        total: result.total,
+        page: result.page,
+        limit: result.limit,
+        totalPages: result.totalPages,
+      },
+    };
+
+    return res.json(response);
+  } catch (error) {
+    console.log('=== WEEK TEMPLATE GET ERROR ===');
+    console.log('Error type:', error?.constructor?.name);
+    console.log('Error message:', (error as any)?.message);
+    
+    if (error instanceof Error && error.message.includes('Access denied')) {
+      return res.status(403).json({ error: error.message });
+    }
+
+    console.error('Unexpected error fetching week templates:', error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
+ * GET /api/families/:familyId/week-templates/:templateId
+ * Get a specific week template by ID
+ */
+router.get('/:familyId/week-templates/:templateId', async (req: AuthenticatedRequest, res: Response) => {
+  console.log('=== WEEK TEMPLATE GET BY ID REQUEST ===');
+  console.log('URL params:', req.params);
+  console.log('User from token:', req.user);
+  
+  try {
+    const { familyId, templateId } = req.params;
+    const userId = req.user!.userId;
+    
+    console.log('Extracted familyId:', familyId);
+    console.log('Extracted templateId:', templateId);
+    console.log('Extracted userId:', userId);
+    
+    if (!familyId || !templateId) {
+      console.log('ERROR: Missing familyId or templateId');
+      return res.status(400).json({ error: 'Family ID and Template ID are required' });
+    }
+
+    console.log('Checking family membership...');
+    // Check if user is a member of the family
+    await checkFamilyMembership(userId, familyId);
+    console.log('Family membership check passed!');
+
+    console.log('Calling weekTemplateService.getWeekTemplateById...');
+    const template = await weekTemplateService.getWeekTemplateById(templateId, familyId);
+    
+    if (!template) {
+      console.log('Week template not found');
+      return res.status(404).json({ error: 'Week template not found' });
+    }
+
+    console.log('Week template found successfully:', template.id);
+    
+    const response: WeekTemplateResponseDto = {
+      id: template.id,
+      name: template.name,
+      description: template.description,
+      isActive: template.isActive,
+      createdAt: template.createdAt.toISOString(),
+      updatedAt: template.updatedAt.toISOString(),
+      familyId: template.familyId,
+      days: template.days.map((day): WeekTemplateDayResponseDto => ({
+        id: day.id,
+        dayOfWeek: day.dayOfWeek,
+        dayTemplateId: day.dayTemplateId,
+        createdAt: day.createdAt.toISOString(),
+        updatedAt: day.updatedAt.toISOString(),
+        weekTemplateId: day.weekTemplateId,
+        dayTemplate: {
+          id: day.dayTemplate.id,
+          name: day.dayTemplate.name,
+          description: day.dayTemplate.description,
+          isActive: day.dayTemplate.isActive,
+          createdAt: day.dayTemplate.createdAt.toISOString(),
+          updatedAt: day.dayTemplate.updatedAt.toISOString(),
+          familyId: day.dayTemplate.familyId,
+          items: day.dayTemplate.items.map((item) => ({
+            id: item.id,
+            memberId: item.memberId,
+            taskId: item.taskId,
+            overrideTime: item.overrideTime,
+            overrideDuration: item.overrideDuration,
+            sortOrder: item.sortOrder,
+            createdAt: item.createdAt.toISOString(),
+            updatedAt: item.updatedAt.toISOString(),
+            dayTemplateId: item.dayTemplateId,
+            member: item.member,
+            task: item.task,
+          })),
+        },
+      })),
+    };
+
+    return res.json(response);
+  } catch (error) {
+    console.log('=== WEEK TEMPLATE GET BY ID ERROR ===');
+    console.log('Error type:', error?.constructor?.name);
+    console.log('Error message:', (error as any)?.message);
+    
+    if (error instanceof Error && error.message.includes('Access denied')) {
+      return res.status(403).json({ error: error.message });
+    }
+
+    console.error('Unexpected error fetching week template:', error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
+ * PUT /api/families/:familyId/week-templates/:templateId
+ * Update a week template
+ */
+router.put('/:familyId/week-templates/:templateId', async (req: AuthenticatedRequest, res: Response) => {
+  console.log('=== WEEK TEMPLATE UPDATE REQUEST ===');
+  console.log('URL params:', req.params);
+  console.log('Request body:', req.body);
+  console.log('User from token:', req.user);
+  
+  try {
+    const { familyId, templateId } = req.params;
+    const userId = req.user!.userId;
+    
+    console.log('Extracted familyId:', familyId);
+    console.log('Extracted templateId:', templateId);
+    console.log('Extracted userId:', userId);
+    
+    if (!familyId || !templateId) {
+      console.log('ERROR: Missing familyId or templateId');
+      return res.status(400).json({ error: 'Family ID and Template ID are required' });
+    }
+
+    console.log('Checking family admin permissions...');
+    // Check if user is admin of the family
+    await checkFamilyAdmin(userId, familyId);
+    console.log('Admin check passed!');
+
+    console.log('Updating week template with service...');
+    const template = await weekTemplateService.updateWeekTemplate(templateId, req.body, familyId);
+    console.log('Week template updated successfully:', template.id);
+    
+    const response: WeekTemplateResponseDto = {
+      id: template.id,
+      name: template.name,
+      description: template.description,
+      isActive: template.isActive,
+      createdAt: template.createdAt.toISOString(),
+      updatedAt: template.updatedAt.toISOString(),
+      familyId: template.familyId,
+      days: template.days.map((day): WeekTemplateDayResponseDto => ({
+        id: day.id,
+        dayOfWeek: day.dayOfWeek,
+        dayTemplateId: day.dayTemplateId,
+        createdAt: day.createdAt.toISOString(),
+        updatedAt: day.updatedAt.toISOString(),
+        weekTemplateId: day.weekTemplateId,
+        dayTemplate: {
+          id: day.dayTemplate.id,
+          name: day.dayTemplate.name,
+          description: day.dayTemplate.description,
+          isActive: day.dayTemplate.isActive,
+          createdAt: day.dayTemplate.createdAt.toISOString(),
+          updatedAt: day.dayTemplate.updatedAt.toISOString(),
+          familyId: day.dayTemplate.familyId,
+          items: day.dayTemplate.items.map((item) => ({
+            id: item.id,
+            memberId: item.memberId,
+            taskId: item.taskId,
+            overrideTime: item.overrideTime,
+            overrideDuration: item.overrideDuration,
+            sortOrder: item.sortOrder,
+            createdAt: item.createdAt.toISOString(),
+            updatedAt: item.updatedAt.toISOString(),
+            dayTemplateId: item.dayTemplateId,
+            member: item.member,
+            task: item.task,
+          })),
+        },
+      })),
+    };
+
+    return res.json(response);
+  } catch (error) {
+    console.log('=== WEEK TEMPLATE UPDATE ERROR ===');
+    console.log('Error type:', error?.constructor?.name);
+    console.log('Error message:', (error as any)?.message);
+    
+    if (error instanceof z.ZodError) {
+      console.log('Zod validation error:', error.errors);
+      return res.status(400).json({
+        error: 'Validation failed',
+        details: error.errors,
+      });
+    }
+    
+    if (error instanceof Error) {
+      if (error.message.includes('Access denied')) {
+        console.log('Access denied error');
+        return res.status(403).json({ error: error.message });
+      }
+      if (error.message.includes('not found')) {
+        console.log('Not found error');
+        return res.status(404).json({ error: error.message });
+      }
+      if (error.message.includes('already exists')) {
+        console.log('Duplicate name error');
+        return res.status(409).json({ error: error.message });
+      }
+    }
+
+    console.error('Unexpected error updating week template:', error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
+ * DELETE /api/families/:familyId/week-templates/:templateId
+ * Delete a week template
+ */
+router.delete('/:familyId/week-templates/:templateId', async (req: AuthenticatedRequest, res: Response) => {
+  console.log('=== WEEK TEMPLATE DELETE REQUEST ===');
+  console.log('URL params:', req.params);
+  console.log('User from token:', req.user);
+  
+  try {
+    const { familyId, templateId } = req.params;
+    const userId = req.user!.userId;
+    
+    console.log('Extracted familyId:', familyId);
+    console.log('Extracted templateId:', templateId);
+    console.log('Extracted userId:', userId);
+    
+    if (!familyId || !templateId) {
+      console.log('ERROR: Missing familyId or templateId');
+      return res.status(400).json({ error: 'Family ID and Template ID are required' });
+    }
+
+    console.log('Checking family admin permissions...');
+    // Check if user is admin of the family
+    await checkFamilyAdmin(userId, familyId);
+    console.log('Admin check passed!');
+
+    console.log('Deleting week template with service...');
+    await weekTemplateService.deleteWeekTemplate(templateId, familyId);
+    console.log('Week template deleted successfully:', templateId);
+    
+    return res.status(204).send();
+  } catch (error) {
+    console.log('=== WEEK TEMPLATE DELETE ERROR ===');
+    console.log('Error type:', error?.constructor?.name);
+    console.log('Error message:', (error as any)?.message);
+    
+    if (error instanceof Error) {
+      if (error.message.includes('Access denied')) {
+        console.log('Access denied error');
+        return res.status(403).json({ error: error.message });
+      }
+      if (error.message.includes('not found')) {
+        console.log('Not found error');
+        return res.status(404).json({ error: error.message });
+      }
+    }
+
+    console.error('Unexpected error deleting week template:', error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// ==================== WEEK TEMPLATE DAY CRUD ====================
+
+/**
+ * POST /api/families/:familyId/week-templates/:templateId/days
+ * Add a day template to a week template
+ */
+router.post('/:familyId/week-templates/:templateId/days', async (req: AuthenticatedRequest, res: Response) => {
+  console.log('=== WEEK TEMPLATE DAY CREATE REQUEST ===');
+  console.log('URL params:', req.params);
+  console.log('Request body:', req.body);
+  console.log('User from token:', req.user);
+  
+  try {
+    const { familyId, templateId } = req.params;
+    const userId = req.user!.userId;
+    
+    console.log('Extracted familyId:', familyId);
+    console.log('Extracted templateId:', templateId);
+    console.log('Extracted userId:', userId);
+    
+    if (!familyId || !templateId) {
+      console.log('ERROR: Missing familyId or templateId');
+      return res.status(400).json({ error: 'Family ID and Template ID are required' });
+    }
+
+    console.log('Checking family admin permissions...');
+    // Check if user is admin of the family
+    await checkFamilyAdmin(userId, familyId);
+    console.log('Admin check passed!');
+
+    console.log('Adding day template to week template with service...');
+    const templateDay = await weekTemplateService.addTemplateDay(templateId, req.body, familyId);
+    console.log('Week template day created successfully:', templateDay.id);
+    
+    const response: WeekTemplateDayResponseDto = {
+      id: templateDay.id,
+      dayOfWeek: templateDay.dayOfWeek,
+      dayTemplateId: templateDay.dayTemplateId,
+      createdAt: templateDay.createdAt.toISOString(),
+      updatedAt: templateDay.updatedAt.toISOString(),
+      weekTemplateId: templateDay.weekTemplateId,
+      dayTemplate: {
+        id: templateDay.dayTemplate.id,
+        name: templateDay.dayTemplate.name,
+        description: templateDay.dayTemplate.description,
+        isActive: templateDay.dayTemplate.isActive,
+        createdAt: templateDay.dayTemplate.createdAt.toISOString(),
+        updatedAt: templateDay.dayTemplate.updatedAt.toISOString(),
+        familyId: templateDay.dayTemplate.familyId,
+        items: templateDay.dayTemplate.items.map((item) => ({
+          id: item.id,
+          memberId: item.memberId,
+          taskId: item.taskId,
+          overrideTime: item.overrideTime,
+          overrideDuration: item.overrideDuration,
+          sortOrder: item.sortOrder,
+          createdAt: item.createdAt.toISOString(),
+          updatedAt: item.updatedAt.toISOString(),
+          dayTemplateId: item.dayTemplateId,
+          member: item.member,
+          task: item.task,
+        })),
+      },
+    };
+
+    return res.status(201).json(response);
+  } catch (error) {
+    console.log('=== WEEK TEMPLATE DAY CREATE ERROR ===');
+    console.log('Error type:', error?.constructor?.name);
+    console.log('Error message:', (error as any)?.message);
+    
+    if (error instanceof z.ZodError) {
+      console.log('Zod validation error:', error.errors);
+      return res.status(400).json({
+        error: 'Validation failed',
+        details: error.errors,
+      });
+    }
+    
+    if (error instanceof Error) {
+      if (error.message.includes('Access denied')) {
+        console.log('Access denied error');
+        return res.status(403).json({ error: error.message });
+      }
+      if (error.message.includes('not found')) {
+        console.log('Not found error');
+        return res.status(404).json({ error: error.message });
+      }
+      if (error.message.includes('already has a template')) {
+        console.log('Day already assigned error');
+        return res.status(409).json({ error: error.message });
+      }
+    }
+
+    console.error('Unexpected error adding day template to week template:', error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
+ * PUT /api/families/:familyId/week-templates/:templateId/days/:dayId
+ * Update a week template day
+ */
+router.put('/:familyId/week-templates/:templateId/days/:dayId', async (req: AuthenticatedRequest, res: Response) => {
+  console.log('=== WEEK TEMPLATE DAY UPDATE REQUEST ===');
+  console.log('URL params:', req.params);
+  console.log('Request body:', req.body);
+  console.log('User from token:', req.user);
+  
+  try {
+    const { familyId, dayId } = req.params;
+    const userId = req.user!.userId;
+    
+    console.log('Extracted familyId:', familyId);
+    console.log('Extracted dayId:', dayId);
+    console.log('Extracted userId:', userId);
+    
+    if (!familyId || !dayId) {
+      console.log('ERROR: Missing familyId or dayId');
+      return res.status(400).json({ error: 'Family ID and Day ID are required' });
+    }
+
+    console.log('Checking family admin permissions...');
+    // Check if user is admin of the family
+    await checkFamilyAdmin(userId, familyId);
+    console.log('Admin check passed!');
+
+    console.log('Updating week template day with service...');
+    const templateDay = await weekTemplateService.updateTemplateDay(dayId, req.body, familyId);
+    console.log('Week template day updated successfully:', templateDay.id);
+    
+    const response: WeekTemplateDayResponseDto = {
+      id: templateDay.id,
+      dayOfWeek: templateDay.dayOfWeek,
+      dayTemplateId: templateDay.dayTemplateId,
+      createdAt: templateDay.createdAt.toISOString(),
+      updatedAt: templateDay.updatedAt.toISOString(),
+      weekTemplateId: templateDay.weekTemplateId,
+      dayTemplate: {
+        id: templateDay.dayTemplate.id,
+        name: templateDay.dayTemplate.name,
+        description: templateDay.dayTemplate.description,
+        isActive: templateDay.dayTemplate.isActive,
+        createdAt: templateDay.dayTemplate.createdAt.toISOString(),
+        updatedAt: templateDay.dayTemplate.updatedAt.toISOString(),
+        familyId: templateDay.dayTemplate.familyId,
+        items: templateDay.dayTemplate.items.map((item) => ({
+          id: item.id,
+          memberId: item.memberId,
+          taskId: item.taskId,
+          overrideTime: item.overrideTime,
+          overrideDuration: item.overrideDuration,
+          sortOrder: item.sortOrder,
+          createdAt: item.createdAt.toISOString(),
+          updatedAt: item.updatedAt.toISOString(),
+          dayTemplateId: item.dayTemplateId,
+          member: item.member,
+          task: item.task,
+        })),
+      },
+    };
+
+    return res.json(response);
+  } catch (error) {
+    console.log('=== WEEK TEMPLATE DAY UPDATE ERROR ===');
+    console.log('Error type:', error?.constructor?.name);
+    console.log('Error message:', (error as any)?.message);
+    
+    if (error instanceof z.ZodError) {
+      console.log('Zod validation error:', error.errors);
+      return res.status(400).json({
+        error: 'Validation failed',
+        details: error.errors,
+      });
+    }
+    
+    if (error instanceof Error) {
+      if (error.message.includes('Access denied')) {
+        console.log('Access denied error');
+        return res.status(403).json({ error: error.message });
+      }
+      if (error.message.includes('not found')) {
+        console.log('Not found error');
+        return res.status(404).json({ error: error.message });
+      }
+    }
+
+    console.error('Unexpected error updating week template day:', error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
+ * DELETE /api/families/:familyId/week-templates/:templateId/days/:dayId
+ * Remove a day template from a week template
+ */
+router.delete('/:familyId/week-templates/:templateId/days/:dayId', async (req: AuthenticatedRequest, res: Response) => {
+  console.log('=== WEEK TEMPLATE DAY DELETE REQUEST ===');
+  console.log('URL params:', req.params);
+  console.log('User from token:', req.user);
+  
+  try {
+    const { familyId, dayId } = req.params;
+    const userId = req.user!.userId;
+    
+    console.log('Extracted familyId:', familyId);
+    console.log('Extracted dayId:', dayId);
+    console.log('Extracted userId:', userId);
+    
+    if (!familyId || !dayId) {
+      console.log('ERROR: Missing familyId or dayId');
+      return res.status(400).json({ error: 'Family ID and Day ID are required' });
+    }
+
+    console.log('Checking family admin permissions...');
+    // Check if user is admin of the family
+    await checkFamilyAdmin(userId, familyId);
+    console.log('Admin check passed!');
+
+    console.log('Removing day template from week template with service...');
+    await weekTemplateService.removeTemplateDay(dayId, familyId);
+    console.log('Week template day removed successfully:', dayId);
+    
+    return res.status(204).send();
+  } catch (error) {
+    console.log('=== WEEK TEMPLATE DAY DELETE ERROR ===');
+    console.log('Error type:', error?.constructor?.name);
+    console.log('Error message:', (error as any)?.message);
+    
+    if (error instanceof Error) {
+      if (error.message.includes('Access denied')) {
+        console.log('Access denied error');
+        return res.status(403).json({ error: error.message });
+      }
+      if (error.message.includes('not found')) {
+        console.log('Not found error');
+        return res.status(404).json({ error: error.message });
+      }
+    }
+
+    console.error('Unexpected error removing week template day:', error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
+ * GET /api/families/:familyId/week-templates/:templateId/days
+ * Get all days for a week template
+ */
+router.get('/:familyId/week-templates/:templateId/days', async (req: AuthenticatedRequest, res: Response) => {
+  console.log('=== WEEK TEMPLATE DAYS GET REQUEST ===');
+  console.log('URL params:', req.params);
+  console.log('User from token:', req.user);
+  
+  try {
+    const { familyId, templateId } = req.params;
+    const userId = req.user!.userId;
+    
+    console.log('Extracted familyId:', familyId);
+    console.log('Extracted templateId:', templateId);
+    console.log('Extracted userId:', userId);
+    
+    if (!familyId || !templateId) {
+      console.log('ERROR: Missing familyId or templateId');
+      return res.status(400).json({ error: 'Family ID and Template ID are required' });
+    }
+
+    console.log('Checking family membership...');
+    // Check if user is a member of the family
+    await checkFamilyMembership(userId, familyId);
+    console.log('Family membership check passed!');
+
+    console.log('Calling weekTemplateService.getTemplateDays...');
+    const days = await weekTemplateService.getTemplateDays(templateId, familyId);
+    console.log('Template days fetched successfully, count:', days.length);
+    
+    const response = days.map((day): WeekTemplateDayResponseDto => ({
+      id: day.id,
+      dayOfWeek: day.dayOfWeek,
+      dayTemplateId: day.dayTemplateId,
+      createdAt: day.createdAt.toISOString(),
+      updatedAt: day.updatedAt.toISOString(),
+      weekTemplateId: day.weekTemplateId,
+      dayTemplate: {
+        id: day.dayTemplate.id,
+        name: day.dayTemplate.name,
+        description: day.dayTemplate.description,
+        isActive: day.dayTemplate.isActive,
+        createdAt: day.dayTemplate.createdAt.toISOString(),
+        updatedAt: day.dayTemplate.updatedAt.toISOString(),
+        familyId: day.dayTemplate.familyId,
+        items: day.dayTemplate.items.map((item) => ({
+          id: item.id,
+          memberId: item.memberId,
+          taskId: item.taskId,
+          overrideTime: item.overrideTime,
+          overrideDuration: item.overrideDuration,
+          sortOrder: item.sortOrder,
+          createdAt: item.createdAt.toISOString(),
+          updatedAt: item.updatedAt.toISOString(),
+          dayTemplateId: item.dayTemplateId,
+          member: item.member,
+          task: item.task,
+        })),
+      },
+    }));
+
+    return res.json(response);
+  } catch (error) {
+    console.log('=== WEEK TEMPLATE DAYS GET ERROR ===');
+    console.log('Error type:', error?.constructor?.name);
+    console.log('Error message:', (error as any)?.message);
+    
+    if (error instanceof Error) {
+      if (error.message.includes('Access denied')) {
+        return res.status(403).json({ error: error.message });
+      }
+      if (error.message.includes('not found')) {
+        return res.status(404).json({ error: error.message });
+      }
+    }
+
+    console.error('Unexpected error fetching week template days:', error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// ==================== WEEK TEMPLATE UTILITY ROUTES ====================
+
+/**
+ * POST /api/families/:familyId/week-templates/:templateId/duplicate
+ * Duplicate a week template
+ */
+router.post('/:familyId/week-templates/:templateId/duplicate', async (req: AuthenticatedRequest, res: Response) => {
+  console.log('=== WEEK TEMPLATE DUPLICATE REQUEST ===');
+  console.log('URL params:', req.params);
+  console.log('Request body:', req.body);
+  console.log('User from token:', req.user);
+  
+  try {
+    const { familyId, templateId } = req.params;
+    const { name } = req.body;
+    const userId = req.user!.userId;
+    
+    console.log('Extracted familyId:', familyId);
+    console.log('Extracted templateId:', templateId);
+    console.log('Extracted new name:', name);
+    console.log('Extracted userId:', userId);
+    
+    if (!familyId || !templateId) {
+      console.log('ERROR: Missing familyId or templateId');
+      return res.status(400).json({ error: 'Family ID and Template ID are required' });
+    }
+
+    if (!name || typeof name !== 'string') {
+      console.log('ERROR: Missing or invalid name');
+      return res.status(400).json({ error: 'Name is required and must be a string' });
+    }
+
+    console.log('Checking family admin permissions...');
+    // Check if user is admin of the family
+    await checkFamilyAdmin(userId, familyId);
+    console.log('Admin check passed!');
+
+    console.log('Duplicating week template with service...');
+    const template = await weekTemplateService.duplicateTemplate(templateId, name, familyId);
+    console.log('Week template duplicated successfully:', template.id);
+    
+    const response: WeekTemplateResponseDto = {
+      id: template.id,
+      name: template.name,
+      description: template.description,
+      isActive: template.isActive,
+      createdAt: template.createdAt.toISOString(),
+      updatedAt: template.updatedAt.toISOString(),
+      familyId: template.familyId,
+      days: template.days.map((day): WeekTemplateDayResponseDto => ({
+        id: day.id,
+        dayOfWeek: day.dayOfWeek,
+        dayTemplateId: day.dayTemplateId,
+        createdAt: day.createdAt.toISOString(),
+        updatedAt: day.updatedAt.toISOString(),
+        weekTemplateId: day.weekTemplateId,
+        dayTemplate: {
+          id: day.dayTemplate.id,
+          name: day.dayTemplate.name,
+          description: day.dayTemplate.description,
+          isActive: day.dayTemplate.isActive,
+          createdAt: day.dayTemplate.createdAt.toISOString(),
+          updatedAt: day.dayTemplate.updatedAt.toISOString(),
+          familyId: day.dayTemplate.familyId,
+          items: day.dayTemplate.items.map((item) => ({
+            id: item.id,
+            memberId: item.memberId,
+            taskId: item.taskId,
+            overrideTime: item.overrideTime,
+            overrideDuration: item.overrideDuration,
+            sortOrder: item.sortOrder,
+            createdAt: item.createdAt.toISOString(),
+            updatedAt: item.updatedAt.toISOString(),
+            dayTemplateId: item.dayTemplateId,
+            member: item.member,
+            task: item.task,
+          })),
+        },
+      })),
+    };
+
+    return res.status(201).json(response);
+  } catch (error) {
+    console.log('=== WEEK TEMPLATE DUPLICATE ERROR ===');
+    console.log('Error type:', error?.constructor?.name);
+    console.log('Error message:', (error as any)?.message);
+    
+    if (error instanceof Error) {
+      if (error.message.includes('Access denied')) {
+        console.log('Access denied error');
+        return res.status(403).json({ error: error.message });
+      }
+      if (error.message.includes('not found')) {
+        console.log('Not found error');
+        return res.status(404).json({ error: error.message });
+      }
+      if (error.message.includes('already exists')) {
+        console.log('Duplicate name error');
+        return res.status(409).json({ error: error.message });
+      }
+    }
+
+    console.error('Unexpected error duplicating week template:', error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
+ * POST /api/families/:familyId/week-templates/:templateId/apply
+ * Apply a week template to a specific week
+ */
+router.post('/:familyId/week-templates/:templateId/apply', async (req: AuthenticatedRequest, res: Response) => {
+  console.log('=== WEEK TEMPLATE APPLY REQUEST ===');
+  console.log('URL params:', req.params);
+  console.log('Request body:', req.body);
+  console.log('User from token:', req.user);
+  
+  try {
+    const { familyId, templateId } = req.params;
+    const userId = req.user!.userId;
+    
+    console.log('Extracted familyId:', familyId);
+    console.log('Extracted templateId:', templateId);
+    console.log('Extracted userId:', userId);
+    
+    if (!familyId || !templateId) {
+      console.log('ERROR: Missing familyId or templateId');
+      return res.status(400).json({ error: 'Family ID and Template ID are required' });
+    }
+
+    console.log('Checking family admin permissions...');
+    // Check if user is admin of the family
+    await checkFamilyAdmin(userId, familyId);
+    console.log('Admin check passed!');
+
+    const applyData: ApplyWeekTemplateDto = {
+      templateId,
+      startDate: req.body.startDate,
+      overrideMemberAssignments: req.body.overrideMemberAssignments || false,
+    };
+
+    console.log('Applying week template with service...');
+    const assignments = await weekTemplateService.applyWeekTemplate(applyData, familyId);
+    console.log('Week template applied successfully, created assignments:', assignments.length);
+    
+    const response = {
+      message: 'Week template applied successfully',
+      assignmentsCreated: assignments.length,
+      assignments: assignments.map((assignment) => ({
+        id: assignment.id,
+        memberId: assignment.memberId,
+        taskId: assignment.taskId,
+        overrideTime: assignment.overrideTime,
+        overrideDuration: assignment.overrideDuration,
+        assignedDate: assignment.assignedDate.toISOString().split('T')[0], // YYYY-MM-DD format
+        createdAt: assignment.createdAt.toISOString(),
+        updatedAt: assignment.updatedAt.toISOString(),
+        member: assignment.member,
+        task: assignment.task,
+      })),
+    };
+
+    return res.status(201).json(response);
+  } catch (error) {
+    console.log('=== WEEK TEMPLATE APPLY ERROR ===');
+    console.log('Error type:', error?.constructor?.name);
+    console.log('Error message:', (error as any)?.message);
+    
+    if (error instanceof Error) {
+      if (error.message.includes('Access denied')) {
+        console.log('Access denied error');
+        return res.status(403).json({ error: error.message });
+      }
+      if (error.message.includes('not found')) {
+        console.log('Not found error');
+        return res.status(404).json({ error: error.message });
+      }
+      if (error.message.includes('Invalid start date')) {
+        console.log('Invalid date error');
+        return res.status(400).json({ error: error.message });
+      }
+      if (error.message.includes('must be a Monday')) {
+        console.log('Invalid start day error');
+        return res.status(400).json({ error: error.message });
+      }
+    }
+
+    console.error('Unexpected error applying week template:', error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+export default router; 

--- a/backend/src/services/week-template.service.ts
+++ b/backend/src/services/week-template.service.ts
@@ -1,0 +1,1001 @@
+import { PrismaClient } from '@prisma/client';
+import {
+  WeekTemplateWithRelations,
+  WeekTemplateDayWithRelations,
+  CreateWeekTemplateDto,
+  UpdateWeekTemplateDto,
+  CreateWeekTemplateDayDto,
+  UpdateWeekTemplateDayDto,
+  WeekTemplateQueryParams,
+  ApplyWeekTemplateDto,
+  CreateWeekTemplateSchema,
+  UpdateWeekTemplateSchema,
+  CreateWeekTemplateDaySchema,
+  UpdateWeekTemplateDaySchema,
+  TaskAssignmentWithRelations,
+} from '../types/task.types';
+
+const prisma = new PrismaClient();
+
+export class WeekTemplateService {
+  
+  // ==================== WEEK TEMPLATE CRUD ====================
+
+  /**
+   * Create a new week template
+   */
+  async createWeekTemplate(
+    data: CreateWeekTemplateDto,
+    familyId: string
+  ): Promise<WeekTemplateWithRelations> {
+    // Validate input data
+    const validatedData = CreateWeekTemplateSchema.parse(data);
+
+    // Check if template name already exists in family
+    const existingTemplate = await prisma.weekTemplate.findFirst({
+      where: {
+        familyId: familyId,
+        name: validatedData.name,
+      },
+    });
+
+    if (existingTemplate) {
+      throw new Error('A week template with this name already exists in this family');
+    }
+
+    // Create the week template
+    const template = await prisma.weekTemplate.create({
+      data: {
+        name: validatedData.name,
+        description: validatedData.description || null,
+        familyId: familyId,
+      },
+      include: {
+        days: {
+          include: {
+            dayTemplate: {
+              include: {
+                items: {
+                  include: {
+                    member: {
+                      select: {
+                        id: true,
+                        firstName: true,
+                        lastName: true,
+                        email: true,
+                        avatarUrl: true,
+                        isVirtual: true,
+                      },
+                    },
+                    task: {
+                      select: {
+                        id: true,
+                        name: true,
+                        description: true,
+                        color: true,
+                        icon: true,
+                        defaultStartTime: true,
+                        defaultDuration: true,
+                        familyId: true,
+                      },
+                    },
+                    dayTemplate: {
+                      select: {
+                        id: true,
+                        name: true,
+                        description: true,
+                      },
+                    },
+                  },
+                  orderBy: {
+                    sortOrder: 'asc',
+                  },
+                },
+                family: {
+                  select: {
+                    id: true,
+                    name: true,
+                  },
+                },
+              },
+            },
+            weekTemplate: {
+              select: {
+                id: true,
+                name: true,
+                description: true,
+              },
+            },
+          },
+          orderBy: {
+            dayOfWeek: 'asc',
+          },
+        },
+        family: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+      },
+    });
+
+    return template;
+  }
+
+  /**
+   * Get a week template by ID
+   */
+  async getWeekTemplateById(
+    id: string,
+    familyId: string
+  ): Promise<WeekTemplateWithRelations | null> {
+    const template = await prisma.weekTemplate.findFirst({
+      where: {
+        id: id,
+        familyId: familyId,
+      },
+      include: {
+        days: {
+          include: {
+            dayTemplate: {
+              include: {
+                items: {
+                  include: {
+                    member: {
+                      select: {
+                        id: true,
+                        firstName: true,
+                        lastName: true,
+                        email: true,
+                        avatarUrl: true,
+                        isVirtual: true,
+                      },
+                    },
+                    task: {
+                      select: {
+                        id: true,
+                        name: true,
+                        description: true,
+                        color: true,
+                        icon: true,
+                        defaultStartTime: true,
+                        defaultDuration: true,
+                        familyId: true,
+                      },
+                    },
+                    dayTemplate: {
+                      select: {
+                        id: true,
+                        name: true,
+                        description: true,
+                      },
+                    },
+                  },
+                  orderBy: {
+                    sortOrder: 'asc',
+                  },
+                },
+                family: {
+                  select: {
+                    id: true,
+                    name: true,
+                  },
+                },
+              },
+            },
+            weekTemplate: {
+              select: {
+                id: true,
+                name: true,
+                description: true,
+              },
+            },
+          },
+          orderBy: {
+            dayOfWeek: 'asc',
+          },
+        },
+        family: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+      },
+    });
+
+    return template;
+  }
+
+  /**
+   * Get all week templates for a family with filtering and pagination
+   */
+  async getWeekTemplates(
+    familyId: string,
+    params: WeekTemplateQueryParams = {}
+  ): Promise<{
+    templates: WeekTemplateWithRelations[];
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+  }> {
+    const {
+      isActive,
+      search,
+      page = 1,
+      limit = 50,
+    } = params;
+
+    // Build where clause
+    const whereClause: any = {
+      familyId: familyId,
+    };
+
+    if (isActive !== undefined) {
+      whereClause.isActive = isActive;
+    }
+
+    if (search) {
+      whereClause.OR = [
+        { name: { contains: search, mode: 'insensitive' } },
+        { description: { contains: search, mode: 'insensitive' } },
+      ];
+    }
+
+    // Get total count for pagination
+    const total = await prisma.weekTemplate.count({
+      where: whereClause,
+    });
+
+    // Get templates with pagination
+    const templates = await prisma.weekTemplate.findMany({
+      where: whereClause,
+      include: {
+        days: {
+          include: {
+            dayTemplate: {
+              include: {
+                items: {
+                  include: {
+                    member: {
+                      select: {
+                        id: true,
+                        firstName: true,
+                        lastName: true,
+                        email: true,
+                        avatarUrl: true,
+                        isVirtual: true,
+                      },
+                    },
+                    task: {
+                      select: {
+                        id: true,
+                        name: true,
+                        description: true,
+                        color: true,
+                        icon: true,
+                        defaultStartTime: true,
+                        defaultDuration: true,
+                        familyId: true,
+                      },
+                    },
+                    dayTemplate: {
+                      select: {
+                        id: true,
+                        name: true,
+                        description: true,
+                      },
+                    },
+                  },
+                  orderBy: {
+                    sortOrder: 'asc',
+                  },
+                },
+                family: {
+                  select: {
+                    id: true,
+                    name: true,
+                  },
+                },
+              },
+            },
+            weekTemplate: {
+              select: {
+                id: true,
+                name: true,
+                description: true,
+              },
+            },
+          },
+          orderBy: {
+            dayOfWeek: 'asc',
+          },
+        },
+        family: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+      },
+      orderBy: [
+        { name: 'asc' },
+      ],
+      skip: (page - 1) * limit,
+      take: limit,
+    });
+
+    const totalPages = Math.ceil(total / limit);
+
+    return {
+      templates,
+      total,
+      page,
+      limit,
+      totalPages,
+    };
+  }
+
+  /**
+   * Update a week template
+   */
+  async updateWeekTemplate(
+    id: string,
+    data: UpdateWeekTemplateDto,
+    familyId: string
+  ): Promise<WeekTemplateWithRelations> {
+    // Validate input data
+    const validatedData = UpdateWeekTemplateSchema.parse(data);
+
+    // Verify template exists and belongs to the family
+    const existingTemplate = await this.getWeekTemplateById(id, familyId);
+    if (!existingTemplate) {
+      throw new Error('Week template not found');
+    }
+
+    // Check if new name conflicts with existing templates (excluding current one)
+    if (validatedData.name && validatedData.name !== existingTemplate.name) {
+      const conflictingTemplate = await prisma.weekTemplate.findFirst({
+        where: {
+          familyId: familyId,
+          name: validatedData.name,
+          id: { not: id },
+        },
+      });
+
+      if (conflictingTemplate) {
+        throw new Error('A week template with this name already exists in this family');
+      }
+    }
+
+    // Build update data object with only defined values
+    const updateData: any = {};
+    if (validatedData.name !== undefined) {
+      updateData.name = validatedData.name;
+    }
+    if (validatedData.description !== undefined) {
+      updateData.description = validatedData.description;
+    }
+    if (validatedData.isActive !== undefined) {
+      updateData.isActive = validatedData.isActive;
+    }
+
+    // Update the template
+    const updatedTemplate = await prisma.weekTemplate.update({
+      where: { id: id },
+      data: updateData,
+      include: {
+        days: {
+          include: {
+            dayTemplate: {
+              include: {
+                items: {
+                  include: {
+                    member: {
+                      select: {
+                        id: true,
+                        firstName: true,
+                        lastName: true,
+                        email: true,
+                        avatarUrl: true,
+                        isVirtual: true,
+                      },
+                    },
+                    task: {
+                      select: {
+                        id: true,
+                        name: true,
+                        description: true,
+                        color: true,
+                        icon: true,
+                        defaultStartTime: true,
+                        defaultDuration: true,
+                        familyId: true,
+                      },
+                    },
+                    dayTemplate: {
+                      select: {
+                        id: true,
+                        name: true,
+                        description: true,
+                      },
+                    },
+                  },
+                  orderBy: {
+                    sortOrder: 'asc',
+                  },
+                },
+                family: {
+                  select: {
+                    id: true,
+                    name: true,
+                  },
+                },
+              },
+            },
+            weekTemplate: {
+              select: {
+                id: true,
+                name: true,
+                description: true,
+              },
+            },
+          },
+          orderBy: {
+            dayOfWeek: 'asc',
+          },
+        },
+        family: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+      },
+    });
+
+    return updatedTemplate;
+  }
+
+  /**
+   * Delete a week template
+   */
+  async deleteWeekTemplate(id: string, familyId: string): Promise<void> {
+    // Verify template exists and belongs to the family
+    const existingTemplate = await this.getWeekTemplateById(id, familyId);
+    if (!existingTemplate) {
+      throw new Error('Week template not found');
+    }
+
+    // Delete the template (cascade will delete template days)
+    await prisma.weekTemplate.delete({
+      where: { id: id },
+    });
+  }
+
+  // ==================== WEEK TEMPLATE DAY CRUD ====================
+
+  /**
+   * Add a day template to a week template
+   */
+  async addTemplateDay(
+    weekTemplateId: string,
+    data: CreateWeekTemplateDayDto,
+    familyId: string
+  ): Promise<WeekTemplateDayWithRelations> {
+    // Validate input data
+    const validatedData = CreateWeekTemplateDaySchema.parse(data);
+
+    // Verify week template exists and belongs to the family
+    const weekTemplate = await this.getWeekTemplateById(weekTemplateId, familyId);
+    if (!weekTemplate) {
+      throw new Error('Week template not found');
+    }
+
+    // Verify day template exists and belongs to the same family
+    const dayTemplate = await prisma.dayTemplate.findFirst({
+      where: {
+        id: validatedData.dayTemplateId,
+        familyId: familyId,
+      },
+    });
+
+    if (!dayTemplate) {
+      throw new Error('Day template not found or does not belong to this family');
+    }
+
+    // Check if this day of week already has a template assigned
+    const existingDay = await prisma.weekTemplateDay.findFirst({
+      where: {
+        weekTemplateId: weekTemplateId,
+        dayOfWeek: validatedData.dayOfWeek,
+      },
+    });
+
+    if (existingDay) {
+      throw new Error(`Day ${validatedData.dayOfWeek} already has a template assigned`);
+    }
+
+    // Create the week template day
+    const weekTemplateDay = await prisma.weekTemplateDay.create({
+      data: {
+        weekTemplateId: weekTemplateId,
+        dayOfWeek: validatedData.dayOfWeek,
+        dayTemplateId: validatedData.dayTemplateId,
+      },
+      include: {
+        dayTemplate: {
+          include: {
+            items: {
+              include: {
+                member: {
+                  select: {
+                    id: true,
+                    firstName: true,
+                    lastName: true,
+                    email: true,
+                    avatarUrl: true,
+                    isVirtual: true,
+                  },
+                },
+                task: {
+                  select: {
+                    id: true,
+                    name: true,
+                    description: true,
+                    color: true,
+                    icon: true,
+                    defaultStartTime: true,
+                    defaultDuration: true,
+                    familyId: true,
+                  },
+                },
+                dayTemplate: {
+                  select: {
+                    id: true,
+                    name: true,
+                    description: true,
+                  },
+                },
+              },
+              orderBy: {
+                sortOrder: 'asc',
+              },
+            },
+            family: {
+              select: {
+                id: true,
+                name: true,
+              },
+            },
+          },
+        },
+        weekTemplate: {
+          select: {
+            id: true,
+            name: true,
+            description: true,
+          },
+        },
+      },
+    });
+
+    return weekTemplateDay;
+  }
+
+  /**
+   * Update a week template day
+   */
+  async updateTemplateDay(
+    weekTemplateDayId: string,
+    data: UpdateWeekTemplateDayDto,
+    familyId: string
+  ): Promise<WeekTemplateDayWithRelations> {
+    // Validate input data
+    const validatedData = UpdateWeekTemplateDaySchema.parse(data);
+
+    // Verify week template day exists
+    const existingDay = await prisma.weekTemplateDay.findUnique({
+      where: { id: weekTemplateDayId },
+      include: {
+        weekTemplate: true,
+      },
+    });
+
+    if (!existingDay || existingDay.weekTemplate.familyId !== familyId) {
+      throw new Error('Week template day not found');
+    }
+
+    // If updating day template, verify it exists and belongs to the same family
+    if (validatedData.dayTemplateId) {
+      const dayTemplate = await prisma.dayTemplate.findFirst({
+        where: {
+          id: validatedData.dayTemplateId,
+          familyId: familyId,
+        },
+      });
+
+      if (!dayTemplate) {
+        throw new Error('Day template not found or does not belong to this family');
+      }
+    }
+
+    // Build update data object with only defined values
+    const updateData: any = {};
+    if (validatedData.dayTemplateId !== undefined) {
+      updateData.dayTemplateId = validatedData.dayTemplateId;
+    }
+
+    // Update the week template day
+    const updatedDay = await prisma.weekTemplateDay.update({
+      where: { id: weekTemplateDayId },
+      data: updateData,
+      include: {
+        dayTemplate: {
+          include: {
+            items: {
+              include: {
+                member: {
+                  select: {
+                    id: true,
+                    firstName: true,
+                    lastName: true,
+                    email: true,
+                    avatarUrl: true,
+                    isVirtual: true,
+                  },
+                },
+                task: {
+                  select: {
+                    id: true,
+                    name: true,
+                    description: true,
+                    color: true,
+                    icon: true,
+                    defaultStartTime: true,
+                    defaultDuration: true,
+                    familyId: true,
+                  },
+                },
+                dayTemplate: {
+                  select: {
+                    id: true,
+                    name: true,
+                    description: true,
+                  },
+                },
+              },
+              orderBy: {
+                sortOrder: 'asc',
+              },
+            },
+            family: {
+              select: {
+                id: true,
+                name: true,
+              },
+            },
+          },
+        },
+        weekTemplate: {
+          select: {
+            id: true,
+            name: true,
+            description: true,
+          },
+        },
+      },
+    });
+
+    return updatedDay;
+  }
+
+  /**
+   * Remove a day template from a week template
+   */
+  async removeTemplateDay(
+    weekTemplateDayId: string,
+    familyId: string
+  ): Promise<void> {
+    // Verify week template day exists
+    const existingDay = await prisma.weekTemplateDay.findUnique({
+      where: { id: weekTemplateDayId },
+      include: {
+        weekTemplate: true,
+      },
+    });
+
+    if (!existingDay || existingDay.weekTemplate.familyId !== familyId) {
+      throw new Error('Week template day not found');
+    }
+
+    // Delete the week template day
+    await prisma.weekTemplateDay.delete({
+      where: { id: weekTemplateDayId },
+    });
+  }
+
+  /**
+   * Get all days for a week template
+   */
+  async getTemplateDays(
+    weekTemplateId: string,
+    familyId: string
+  ): Promise<WeekTemplateDayWithRelations[]> {
+    // Verify week template exists and belongs to the family
+    const weekTemplate = await prisma.weekTemplate.findFirst({
+      where: {
+        id: weekTemplateId,
+        familyId: familyId,
+      },
+    });
+
+    if (!weekTemplate) {
+      throw new Error('Week template not found');
+    }
+
+    // Get all week template days
+    const days = await prisma.weekTemplateDay.findMany({
+      where: {
+        weekTemplateId: weekTemplateId,
+      },
+      include: {
+        dayTemplate: {
+          include: {
+            items: {
+              include: {
+                member: {
+                  select: {
+                    id: true,
+                    firstName: true,
+                    lastName: true,
+                    email: true,
+                    avatarUrl: true,
+                    isVirtual: true,
+                  },
+                },
+                task: {
+                  select: {
+                    id: true,
+                    name: true,
+                    description: true,
+                    color: true,
+                    icon: true,
+                    defaultStartTime: true,
+                    defaultDuration: true,
+                    familyId: true,
+                  },
+                },
+                dayTemplate: {
+                  select: {
+                    id: true,
+                    name: true,
+                    description: true,
+                  },
+                },
+              },
+              orderBy: {
+                sortOrder: 'asc',
+              },
+            },
+            family: {
+              select: {
+                id: true,
+                name: true,
+              },
+            },
+          },
+        },
+        weekTemplate: {
+          select: {
+            id: true,
+            name: true,
+            description: true,
+          },
+        },
+      },
+      orderBy: {
+        dayOfWeek: 'asc',
+      },
+    });
+
+    return days;
+  }
+
+  // ==================== WEEK TEMPLATE UTILITY METHODS ====================
+
+  /**
+   * Duplicate a week template
+   */
+  async duplicateTemplate(
+    templateId: string,
+    newName: string,
+    familyId: string
+  ): Promise<WeekTemplateWithRelations> {
+    // Verify source template exists and belongs to the family
+    const sourceTemplate = await this.getWeekTemplateById(templateId, familyId);
+    if (!sourceTemplate) {
+      throw new Error('Source week template not found');
+    }
+
+    // Check if new name conflicts with existing templates
+    const conflictingTemplate = await prisma.weekTemplate.findFirst({
+      where: {
+        familyId: familyId,
+        name: newName,
+      },
+    });
+
+    if (conflictingTemplate) {
+      throw new Error('A week template with this name already exists in this family');
+    }
+
+    // Create new template with all days in a transaction
+    const newTemplate = await prisma.$transaction(async (tx) => {
+      // Create the new template
+      const template = await tx.weekTemplate.create({
+        data: {
+          name: newName,
+          description: sourceTemplate.description,
+          familyId: familyId,
+        },
+      });
+
+      // Copy all template days
+      for (const day of sourceTemplate.days) {
+        await tx.weekTemplateDay.create({
+          data: {
+            weekTemplateId: template.id,
+            dayOfWeek: day.dayOfWeek,
+            dayTemplateId: day.dayTemplateId,
+          },
+        });
+      }
+
+      // Return the complete template with days
+      return await tx.weekTemplate.findUnique({
+        where: { id: template.id },
+        include: {
+          days: {
+            include: {
+              dayTemplate: {
+                include: {
+                  items: {
+                    include: {
+                      member: {
+                        select: {
+                          id: true,
+                          firstName: true,
+                          lastName: true,
+                          email: true,
+                          avatarUrl: true,
+                          isVirtual: true,
+                        },
+                      },
+                      task: {
+                        select: {
+                          id: true,
+                          name: true,
+                          description: true,
+                          color: true,
+                          icon: true,
+                          defaultStartTime: true,
+                          defaultDuration: true,
+                          familyId: true,
+                        },
+                      },
+                      dayTemplate: {
+                        select: {
+                          id: true,
+                          name: true,
+                          description: true,
+                        },
+                      },
+                    },
+                    orderBy: {
+                      sortOrder: 'asc',
+                    },
+                  },
+                  family: {
+                    select: {
+                      id: true,
+                      name: true,
+                    },
+                  },
+                },
+              },
+              weekTemplate: {
+                select: {
+                  id: true,
+                  name: true,
+                  description: true,
+                },
+              },
+            },
+            orderBy: {
+              dayOfWeek: 'asc',
+            },
+          },
+          family: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
+        },
+      });
+    });
+
+    return newTemplate!;
+  }
+
+  /**
+   * Apply a week template to a specific week
+   * Creates task assignments for all days in the week based on the template
+   */
+  async applyWeekTemplate(
+    data: ApplyWeekTemplateDto,
+    familyId: string
+  ): Promise<TaskAssignmentWithRelations[]> {
+    const { templateId, startDate, overrideMemberAssignments = false } = data;
+
+    // Verify week template exists and belongs to the family
+    const weekTemplate = await this.getWeekTemplateById(templateId, familyId);
+    if (!weekTemplate) {
+      throw new Error('Week template not found');
+    }
+
+    // Parse start date and calculate all dates for the week
+    const startDateObj = new Date(startDate);
+    if (isNaN(startDateObj.getTime())) {
+      throw new Error('Invalid start date format');
+    }
+
+    // Ensure start date is a Monday (day 1)
+    const dayOfWeek = startDateObj.getDay();
+    if (dayOfWeek !== 1) {
+      throw new Error('Start date must be a Monday');
+    }
+
+    const weekDates: Date[] = [];
+    for (let i = 0; i < 7; i++) {
+      const date = new Date(startDateObj);
+      date.setDate(startDateObj.getDate() + i);
+      weekDates.push(date);
+    }
+
+    const createdAssignments: TaskAssignmentWithRelations[] = [];
+
+    // Apply each day template to its corresponding date
+    for (const weekTemplateDay of weekTemplate.days) {
+      // Convert ISO day of week (0=Sunday, 1=Monday, ..., 6=Saturday) to array index (0=Monday, ..., 6=Sunday)
+      const dateIndex = weekTemplateDay.dayOfWeek === 0 ? 6 : weekTemplateDay.dayOfWeek - 1;
+      const targetDate = weekDates[dateIndex];
+      
+      if (!targetDate) {
+        throw new Error(`Invalid day of week: ${weekTemplateDay.dayOfWeek}`);
+      }
+      
+      // Apply the day template to this specific date
+      const dayTemplateService = new (await import('./day-template.service')).DayTemplateService();
+      const dateString = targetDate.toISOString().split('T')[0]!; // Convert to YYYY-MM-DD
+      const assignments = await dayTemplateService.applyTemplate(
+        {
+          templateId: weekTemplateDay.dayTemplateId,
+          dates: [dateString],
+          overrideMemberAssignments,
+        },
+        familyId
+      );
+
+      createdAssignments.push(...assignments);
+    }
+
+    return createdAssignments;
+  }
+}
+
+// Export singleton instance
+export const weekTemplateService = new WeekTemplateService(); 

--- a/backend/src/types/task.types.ts
+++ b/backend/src/types/task.types.ts
@@ -360,4 +360,110 @@ export interface ApplyDayTemplateDto {
   templateId: string;
   dates: string[]; // Array of ISO date strings (YYYY-MM-DD)
   overrideMemberAssignments?: boolean; // Whether to override existing member assignments
+}
+
+// ==================== WEEK TEMPLATE TYPES ====================
+
+// WeekTemplate interface matching Prisma model
+export interface WeekTemplate {
+  id: string;
+  name: string;
+  description: string | null;
+  isActive: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+  familyId: string;
+}
+
+// WeekTemplateDay interface matching Prisma model
+export interface WeekTemplateDay {
+  id: string;
+  dayOfWeek: number; // 0 = Sunday, 1 = Monday, ..., 6 = Saturday
+  dayTemplateId: string;
+  createdAt: Date;
+  updatedAt: Date;
+  weekTemplateId: string;
+}
+
+// WeekTemplate with related data
+export interface WeekTemplateWithRelations extends WeekTemplate {
+  days: WeekTemplateDayWithRelations[];
+  family: {
+    id: string;
+    name: string;
+  };
+}
+
+// WeekTemplateDay with related data
+export interface WeekTemplateDayWithRelations extends WeekTemplateDay {
+  dayTemplate: DayTemplateWithRelations;
+  weekTemplate: {
+    id: string;
+    name: string;
+    description: string | null;
+  };
+}
+
+// WeekTemplate validation schemas
+export const CreateWeekTemplateSchema = z.object({
+  name: z.string().min(1, 'Template name is required').max(100, 'Template name is too long'),
+  description: z.string().max(500, 'Description is too long').optional().nullable(),
+});
+
+export const UpdateWeekTemplateSchema = z.object({
+  name: z.string().min(1, 'Template name is required').max(100, 'Template name is too long').optional(),
+  description: z.string().max(500, 'Description is too long').optional().nullable(),
+  isActive: z.boolean().optional(),
+});
+
+// WeekTemplateDay validation schemas
+export const CreateWeekTemplateDaySchema = z.object({
+  dayOfWeek: z.number().int().min(0).max(6), // 0 = Sunday, 6 = Saturday
+  dayTemplateId: z.string().min(1, 'Day template ID is required'),
+});
+
+export const UpdateWeekTemplateDaySchema = z.object({
+  dayTemplateId: z.string().min(1, 'Day template ID is required').optional(),
+});
+
+// DTOs for API requests/responses
+export type CreateWeekTemplateDto = z.infer<typeof CreateWeekTemplateSchema>;
+export type UpdateWeekTemplateDto = z.infer<typeof UpdateWeekTemplateSchema>;
+export type CreateWeekTemplateDayDto = z.infer<typeof CreateWeekTemplateDaySchema>;
+export type UpdateWeekTemplateDayDto = z.infer<typeof UpdateWeekTemplateDaySchema>;
+
+export interface WeekTemplateResponseDto {
+  id: string;
+  name: string;
+  description: string | null;
+  isActive: boolean;
+  createdAt: string; // ISO string for API responses
+  updatedAt: string; // ISO string for API responses
+  familyId: string;
+  days?: WeekTemplateDayResponseDto[];
+}
+
+export interface WeekTemplateDayResponseDto {
+  id: string;
+  dayOfWeek: number;
+  dayTemplateId: string;
+  createdAt: string; // ISO string for API responses
+  updatedAt: string; // ISO string for API responses
+  weekTemplateId: string;
+  dayTemplate?: DayTemplateResponseDto;
+}
+
+// Query parameters for listing week templates
+export interface WeekTemplateQueryParams {
+  isActive?: boolean;
+  search?: string; // Search in name or description
+  page?: number;
+  limit?: number;
+}
+
+// DTO for applying a week template to specific dates
+export interface ApplyWeekTemplateDto {
+  templateId: string;
+  startDate: string; // ISO date string (YYYY-MM-DD) for the Monday of the week
+  overrideMemberAssignments?: boolean; // Whether to override existing member assignments
 } 


### PR DESCRIPTION
## Overview
This PR implements comprehensive WeekTemplate backend functionality, allowing families to create reusable weekly schedules by combining existing DayTemplates.

## Changes Made

### Database Schema
- **WeekTemplate model**: Contains id, name, description, isActive, familyId with unique constraint per family
- **WeekTemplateDay model**: Links dayOfWeek (0-6) to dayTemplateId with unique constraint per week template
- **Updated relationships**: Added weekTemplates to Family model and weekTemplateDays to DayTemplate model

### TypeScript Types and Validation
- Core interfaces: WeekTemplate, WeekTemplateDay
- Relations interfaces: WeekTemplateWithRelations, WeekTemplateDayWithRelations  
- Zod validation schemas: CreateWeekTemplateSchema, UpdateWeekTemplateSchema, CreateWeekTemplateDaySchema, UpdateWeekTemplateDaySchema
- DTOs: WeekTemplateResponseDto, WeekTemplateDayResponseDto
- Query parameters and apply template DTOs

### Service Layer (week-template.service.ts)
**WeekTemplate CRUD:**
- createWeekTemplate: Creates with name uniqueness validation
- getWeekTemplateById: Retrieves with full relations including nested DayTemplate items
- getWeekTemplates: Lists with filtering, search, pagination
- updateWeekTemplate: Updates with conflict checking
- deleteWeekTemplate: Deletes with cascade

**WeekTemplateDay Management:**
- addTemplateDay: Assigns DayTemplate to specific day of week
- updateTemplateDay: Changes DayTemplate assignment  
- removeTemplateDay: Removes day assignment
- getTemplateDays: Gets all days for a week template

**Utility Methods:**
- duplicateTemplate: Clones week template with all days
- applyWeekTemplate: Applies template to create task assignments for full week starting from Monday

### API Routes (week-template.routes.ts)
- GET/POST /api/families/:familyId/week-templates (list/create)
- GET/PUT/DELETE /api/families/:familyId/week-templates/:templateId (get/update/delete)
- GET/POST /api/families/:familyId/week-templates/:templateId/days (list/add days)
- PUT/DELETE /api/families/:familyId/week-templates/:templateId/days/:dayId (update/remove days)
- POST /api/families/:familyId/week-templates/:templateId/duplicate (duplicate)
- POST /api/families/:familyId/week-templates/:templateId/apply (apply to week)

All routes include proper authentication, family membership/admin validation, error handling, and detailed logging.

## Technical Details
- Integrated with existing DayTemplate service for week application
- Proper security with family membership and admin validation
- Comprehensive error handling and logging
- Ready for frontend integration and testing
- Database schema updated using `npx prisma db push`

## Testing
- Backend builds successfully without TypeScript errors
- Database schema applied successfully
- Ready for comprehensive testing with frontend integration

This provides a powerful foundation for weekly planning functionality where families can create reusable weekly schedules.