### PR TITLE
Remove obsolete Apply Template functionality

### DIFF
--- a/frontend/src/features/week/components/WeekTemplateManagement.tsx
+++ b/frontend/src/features/week/components/WeekTemplateManagement.tsx
@@ -30,13 +30,6 @@ export const WeekTemplateManagement: React.FC = () => {
   const [assigningDays, setAssigningDays] = useState<string | null>(null); // templateId when assigning days
   const [selectedDayTemplates, setSelectedDayTemplates] = useState<Record<number, string>>({});
 
-  // Week application state
-  const [applyingTemplate, setApplyingTemplate] = useState<string | null>(null);
-  const [applyData, setApplyData] = useState({
-    startDate: '',
-    overrideMemberAssignments: false,
-  });
-
   const isAdmin = currentFamily?.userRole === 'ADMIN';
 
   useEffect(() => {
@@ -372,40 +365,6 @@ export const WeekTemplateManagement: React.FC = () => {
     }
   };
 
-  const handleApplyTemplate = (templateId: string) => {
-    setApplyingTemplate(templateId);
-    setApplyData({
-      startDate: getNextMonday(),
-      overrideMemberAssignments: false,
-    });
-    setMessage(null);
-  };
-
-  const handleCancelApplyTemplate = () => {
-    setApplyingTemplate(null);
-    setApplyData({
-      startDate: '',
-      overrideMemberAssignments: false,
-    });
-  };
-
-  const handleApplyTemplateSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!currentFamily || !applyingTemplate || !applyData.startDate) return;
-
-    try {
-      await weekTemplateApi.applyTemplate(currentFamily.id, applyingTemplate, {
-        startDate: applyData.startDate,
-        overrideMemberAssignments: applyData.overrideMemberAssignments,
-      });
-      // Backend returns success directly, no need to check response.data.success
-      setMessage({ type: 'success', text: t('weeklyRoutines.applySuccess') });
-      handleCancelApplyTemplate();
-    } catch (error: any) {
-      setMessage({ type: 'error', text: error.response?.data?.message || t('weeklyRoutines.applyError') });
-    }
-  };
-
   const getDayName = (dayOfWeek: number): string => {
     const days = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
     const dayKey = days[dayOfWeek];
@@ -598,13 +557,6 @@ export const WeekTemplateManagement: React.FC = () => {
                       </div>
                     </div>
                     <div className="week-template-management-template-actions">
-                      <button
-                        onClick={() => handleApplyTemplate(template.id)}
-                        className="week-template-management-template-action week-template-management-button week-template-management-button-primary week-template-management-button-sm"
-                        title={t('weeklyRoutines.actions.apply')}
-                      >
-                        ▶️ {t('weeklyRoutines.actions.apply')}
-                      </button>
                       {isAdmin && (
                         <>
                           <button
@@ -792,74 +744,6 @@ export const WeekTemplateManagement: React.FC = () => {
                   {t('weeklyRoutines.assignDays.save')}
                 </button>
               </div>
-            </div>
-          </div>
-        )}
-
-        {/* Apply Template Modal */}
-        {applyingTemplate && (
-          <div className="week-template-management-modal-overlay">
-            <div className="week-template-management-modal">
-              <div className="week-template-management-modal-header">
-                <h3>{t('weeklyRoutines.apply.title')}</h3>
-                <button
-                  onClick={handleCancelApplyTemplate}
-                  className="week-template-management-modal-close"
-                >
-                  ✕
-                </button>
-              </div>
-              <form onSubmit={handleApplyTemplateSubmit} className="week-template-management-modal-content">
-                <p>{t('weeklyRoutines.apply.description')}</p>
-                
-                <div className="week-template-management-form-group">
-                  <label className="week-template-management-label">
-                    {t('weeklyRoutines.apply.startDate')} *
-                  </label>
-                  <input
-                    type="date"
-                    value={applyData.startDate}
-                    onChange={(e) => setApplyData(prev => ({ ...prev, startDate: e.target.value }))}
-                    className="week-template-management-input"
-                    min={getNextMonday()}
-                    required
-                  />
-                  <div className="week-template-management-help-text">
-                    {t('weeklyRoutines.apply.startDateHelp')}
-                  </div>
-                </div>
-
-                <div className="week-template-management-form-group">
-                  <label className="week-template-management-checkbox-label">
-                    <input
-                      type="checkbox"
-                      checked={applyData.overrideMemberAssignments}
-                      onChange={(e) => setApplyData(prev => ({ ...prev, overrideMemberAssignments: e.target.checked }))}
-                    />
-                    {t('weeklyRoutines.apply.overrideAssignments')}
-                  </label>
-                  <div className="week-template-management-help-text">
-                    {t('weeklyRoutines.apply.overrideAssignmentsHelp')}
-                  </div>
-                </div>
-
-                <div className="week-template-management-modal-actions">
-                  <button
-                    type="button"
-                    onClick={handleCancelApplyTemplate}
-                    className="week-template-management-button week-template-management-button-secondary"
-                  >
-                    {t('common.cancel')}
-                  </button>
-                  <button
-                    type="submit"
-                    className="week-template-management-button week-template-management-button-primary"
-                    disabled={!applyData.startDate}
-                  >
-                    {t('weeklyRoutines.apply.confirm')}
-                  </button>
-                </div>
-              </form>
             </div>
           </div>
         )}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -351,8 +351,7 @@
     "duplicateSuccess": "Weekly routine duplicated successfully",
     "duplicateError": "Failed to duplicate weekly routine",
     "duplicatePrompt": "Enter a name for the duplicated routine:",
-    "applySuccess": "Weekly routine applied successfully",
-    "applyError": "Failed to apply weekly routine",
+
     "daysAssignedSuccess": "Day assignments saved successfully",
     "daysAssignError": "Failed to save day assignments",
     "daysAssigned": "days assigned",
@@ -383,7 +382,6 @@
       "nameExists": "A routine with this name already exists"
     },
     "actions": {
-      "apply": "Apply",
       "assignDays": "Assign Days",
       "duplicate": "Duplicate",
       "edit": "Edit",
@@ -395,15 +393,7 @@
       "selectRoutine": "Select a daily routine...",
       "save": "Save Assignments"
     },
-    "apply": {
-      "title": "Apply Weekly Routine",
-      "description": "Apply this routine to create task assignments for a full week.",
-      "startDate": "Start Date (Monday)",
-      "startDateHelp": "Select the Monday when this week should start",
-      "overrideAssignments": "Override existing assignments",
-      "overrideAssignmentsHelp": "Replace any existing task assignments for this week",
-      "confirm": "Apply Routine"
-    },
+
     "days": {
       "sunday": "Sunday",
       "monday": "Monday",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -351,8 +351,7 @@
     "duplicateSuccess": "Routine hebdomadaire dupliquée avec succès",
     "duplicateError": "Échec de la duplication de la routine hebdomadaire",
     "duplicatePrompt": "Entrez un nom pour la routine dupliquée :",
-    "applySuccess": "Routine hebdomadaire appliquée avec succès",
-    "applyError": "Échec de l'application de la routine hebdomadaire",
+
     "daysAssignedSuccess": "Affectations de jours sauvegardées avec succès",
     "daysAssignError": "Échec de la sauvegarde des affectations de jours",
     "daysAssigned": "jours affectés",
@@ -383,7 +382,6 @@
       "nameExists": "Une routine avec ce nom existe déjà"
     },
     "actions": {
-      "apply": "Appliquer",
       "assignDays": "Affecter les Jours",
       "duplicate": "Dupliquer",
       "edit": "Modifier",
@@ -395,15 +393,7 @@
       "selectRoutine": "Sélectionnez une routine quotidienne...",
       "save": "Sauvegarder les Affectations"
     },
-    "apply": {
-      "title": "Appliquer la Routine Hebdomadaire",
-      "description": "Appliquez cette routine pour créer des affectations de tâches pour une semaine complète.",
-      "startDate": "Date de Début (Lundi)",
-      "startDateHelp": "Sélectionnez le lundi où cette semaine devrait commencer",
-      "overrideAssignments": "Remplacer les affectations existantes",
-      "overrideAssignmentsHelp": "Remplacer toutes les affectations de tâches existantes pour cette semaine",
-      "confirm": "Appliquer la Routine"
-    },
+
     "days": {
       "sunday": "Dimanche",
       "monday": "Lundi",

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -190,9 +190,7 @@ export const weekTemplateApi = {
     return await apiClient.post(`/families/${familyId}/week-templates/${templateId}/duplicate`, data);
   },
   
-  async applyTemplate(familyId: string, templateId: string, data: any) {
-    return await apiClient.post(`/families/${familyId}/week-templates/${templateId}/apply`, data);
-  },
+
   
   // Template days
   async getTemplateDays(familyId: string, templateId: string) {


### PR DESCRIPTION
Removes the outdated Apply Template functionality that was trying to create TaskAssignment records. The new WeekScheduleService with WeekOverride/TaskOverride pattern handles actual scheduling. Templates now serve as pure blueprints for the new system.