### PR TITLE
Fix missing task icon in TaskOverrideCard component

### DIFF
--- a/frontend/src/__tests__/TaskManagement.test.tsx
+++ b/frontend/src/__tests__/TaskManagement.test.tsx
@@ -529,7 +529,15 @@ describe('TaskManagement', () => {
       expect(screen.getByText('Evening Task')).toBeDefined();
       
       // Verify chronological order by checking the DOM structure
-      const taskNames = screen.getAllByText(/(Morning|Afternoon|Evening) Task$/).map(el => el.textContent);
+      // Get task names by finding h4 elements with task-override-card-name class
+      const taskNameElements = document.querySelectorAll('.task-override-card-name');
+      const taskNames = Array.from(taskNameElements).map(el => {
+        // Remove the icon text (first part) and get just the task name
+        const fullText = el.textContent || '';
+        const iconElement = el.querySelector('.task-override-card-icon');
+        const iconText = iconElement?.textContent || '';
+        return fullText.replace(iconText, '').trim();
+      });
       expect(taskNames).toEqual(['Morning Task', 'Afternoon Task', 'Evening Task']);
     });
   });

--- a/frontend/src/components/ui/TaskOverrideCard.css
+++ b/frontend/src/components/ui/TaskOverrideCard.css
@@ -38,6 +38,15 @@
   color: #111827;
   line-height: 1.3;
   word-wrap: break-word;
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.task-override-card-icon {
+  font-size: 0.875rem;
+  flex-shrink: 0;
+  line-height: 1;
 }
 
 .task-override-card-name.clickable {
@@ -271,6 +280,11 @@
   font-size: 0.625rem;
   margin: 0 0 0.125rem 0;
   line-height: 1.2;
+  gap: 0.25rem;
+}
+
+.task-override-card.compact .task-override-card-icon {
+  font-size: 0.75rem;
 }
 
 .task-override-card.compact .task-override-card-tags {

--- a/frontend/src/components/ui/TaskOverrideCard.tsx
+++ b/frontend/src/components/ui/TaskOverrideCard.tsx
@@ -43,6 +43,7 @@ export const TaskOverrideCard: React.FC<TaskOverrideCardProps> = ({
       <div className="task-override-card-main">
         <div className="task-override-card-info">
           <h4 className="task-override-card-name">
+            <span className="task-override-card-icon">{task.task.icon || '✅'}</span>
             {task.task.name}
           </h4>
           <div className="task-override-card-tags">


### PR DESCRIPTION
## 🐛 Bug Fix: Missing Task Icon in TaskOverrideCard

### Issue
The TaskOverrideCard component was not displaying task icons, which should appear on the left of the task title with appropriate sizing.

### Solution
- ✅ Added task icon display using `task.task.icon` property
- ✅ Icon appears on the left of the title with proper spacing
- ✅ Consistent sizing: 0.875rem (normal), 0.75rem (compact mode)
- ✅ Proper CSS styling with flexbox layout for alignment
- ✅ Matches TaskAssignmentCard component implementation
- ✅ Uses default ✅ emoji when no icon is specified

### Technical Changes
1. **TaskOverrideCard.tsx**: Added icon span element with `task.task.icon || '✅'`
2. **TaskOverrideCard.css**: Added flexbox styling and icon-specific CSS classes
3. **Compact Mode Support**: Smaller icon size for compact layout

### Testing
- ✅ All 16 TaskOverrideCard tests passing
- ✅ Frontend build successful
- ✅ Linting passed
- ✅ Consistent with existing icon patterns

### Visual Impact
Task icons now appear consistently across all task card components, improving visual consistency and user experience.