### PR TITLE
fix: Use npm install instead of npm ci in GitHub Actions

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -25,12 +25,12 @@ jobs:
       - name: Install backend dependencies
         run: |
           cd backend
-          npm ci
+          npm install
 
       - name: Install frontend dependencies
         run: |
           cd frontend
-          npm ci
+          npm install
 
       - name: Run backend tests
         run: |


### PR DESCRIPTION
## Problem

The CD pipeline was failing with 'jest: not found' errors because the GitHub Actions workflow was using `npm ci` but the project doesn't have `package-lock.json` files in the backend and frontend subdirectories due to workspace configuration.

## Solution

Changed the GitHub Actions workflow to use `npm install` instead of `npm ci` in both backend and frontend dependency installation steps.

## Changes

- Updated `.github/workflows/deploy-production.yml`
- Changed `npm ci` to `npm install` for backend dependencies
- Changed `npm ci` to `npm install` for frontend dependencies

## Testing

This fixes the CI/CD pipeline that was failing at the test stage, allowing the deployment to proceed to the EC2 instance with the Docker memory optimizations.

Fixes the Jest dependency issue in the CD pipeline.