### PR TITLE
fix: Add Prisma generate step to GitHub Actions workflow

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -27,6 +27,11 @@ jobs:
           cd backend
           npm install
 
+      - name: Generate Prisma client
+        run: |
+          cd backend
+          npx prisma generate
+
       - name: Install frontend dependencies
         run: |
           cd frontend


### PR DESCRIPTION
## Problem

The CD pipeline was failing because the backend tests couldn't run due to Prisma client not being initialized. All tests were failing with:

```
@prisma/client did not initialize yet. Please run "prisma generate" and try to import it again.
```

## Solution

Added a `Generate Prisma client` step to the GitHub Actions workflow that runs `npx prisma generate` after installing backend dependencies but before running tests.

## Changes

- Added new step in `.github/workflows/deploy-production.yml`
- Step runs `npx prisma generate` in the backend directory
- Positioned after dependency installation but before tests

## Testing

This ensures that the Prisma client is properly generated and available for all backend tests, allowing the CI/CD pipeline to pass and proceed with deployment to EC2.

Fixes the Prisma client initialization error in the CD pipeline.