### PR TITLE
fix: E2E tests - correct health endpoint path and use npm install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
         cache: 'npm'
 
     - name: Install dependencies
-      run: npm ci
+      run: npm install
 
     - name: Install backend dependencies
-      run: cd backend && npm ci
+      run: cd backend && npm install
 
     - name: Generate Prisma client
       run: cd backend && npx prisma generate
@@ -49,10 +49,10 @@ jobs:
         cache: 'npm'
 
     - name: Install dependencies
-      run: npm ci
+      run: npm install
 
     - name: Install backend dependencies
-      run: cd backend && npm ci
+      run: cd backend && npm install
 
     - name: Generate Prisma client
       run: cd backend && npx prisma generate
@@ -104,10 +104,10 @@ jobs:
         cache: 'npm'
 
     - name: Install dependencies
-      run: npm ci
+      run: npm install
 
     - name: Install frontend dependencies
-      run: cd frontend && npm ci
+      run: cd frontend && npm install
 
     - name: Test frontend
       run: cd frontend && npm test
@@ -127,13 +127,13 @@ jobs:
         cache: 'npm'
 
     - name: Install dependencies
-      run: npm ci
+      run: npm install
 
     - name: Install backend dependencies
-      run: cd backend && npm ci
+      run: cd backend && npm install
 
     - name: Install frontend dependencies
-      run: cd frontend && npm ci
+      run: cd frontend && npm install
 
     - name: Generate Prisma client
       run: cd backend && npx prisma generate
@@ -168,19 +168,19 @@ jobs:
         cache: 'npm'
 
     - name: Install dependencies
-      run: npm ci
+      run: npm install
 
     - name: Install backend dependencies
-      run: cd backend && npm ci
+      run: cd backend && npm install
 
     - name: Install frontend dependencies
-      run: cd frontend && npm ci
+      run: cd frontend && npm install
 
     - name: Install E2E test dependencies
-      run: cd e2e-tests && npm ci
+      run: cd e2e-tests && npm install
 
     - name: Install frontend dependencies for build
-      run: cd frontend && npm ci
+      run: cd frontend && npm install
 
     - name: Install Playwright browsers
       run: cd e2e-tests && npx playwright install chromium
@@ -210,7 +210,7 @@ jobs:
         
         # Wait for services to be ready
         echo "Waiting for services to be ready..."
-        timeout 120 bash -c 'until curl -f http://localhost:3001/health; do echo "Waiting for backend..."; sleep 3; done'
+        timeout 120 bash -c 'until curl -f http://localhost:3001/api/health; do echo "Waiting for backend..."; sleep 3; done'
         timeout 120 bash -c 'until curl -f http://localhost:3000; do echo "Waiting for frontend..."; sleep 3; done'
         
         # Initialize database schema


### PR DESCRIPTION
## Problem
The E2E tests in GitHub Actions were failing with 404 errors because:
1. Health check was trying to access  but the endpoint is at 
2. Using 
added 786 packages, and audited 790 packages in 3s

149 packages are looking for funding
  run `npm fund` for details

7 vulnerabilities (1 low, 6 moderate)

To address issues that do not require attention, run:
  npm audit fix

To address all issues (including breaking changes), run:
  npm audit fix --force

Run `npm audit` for details. but package-lock.json files are missing

## Solution
- Fixed health check endpoint from  to  in E2E tests
- Changed 
added 786 packages, and audited 790 packages in 3s

149 packages are looking for funding
  run `npm fund` for details

7 vulnerabilities (1 low, 6 moderate)

To address issues that do not require attention, run:
  npm audit fix

To address all issues (including breaking changes), run:
  npm audit fix --force

Run `npm audit` for details. to 
up to date, audited 790 packages in 659ms

149 packages are looking for funding
  run `npm fund` for details

7 vulnerabilities (1 low, 6 moderate)

To address issues that do not require attention, run:
  npm audit fix

To address all issues (including breaking changes), run:
  npm audit fix --force

Run `npm audit` for details. throughout CI workflow to avoid package-lock.json dependency issues

## Testing
This should resolve the 404 errors in E2E test health checks and allow the CI pipeline to run successfully.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update