### PR TITLE
fix: Frontend nginx configuration - remove invalid must-revalidate directive

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -10,7 +10,7 @@ server {
     gzip on;
     gzip_vary on;
     gzip_min_length 1024;
-    gzip_proxied expired no-cache no-store private must-revalidate auth;
+    gzip_proxied expired no-cache no-store private auth;
     gzip_types
         text/plain
         text/css


### PR DESCRIPTION
## Problem
The frontend container is continuously crashing and restarting due to an invalid nginx configuration.

**Error:**
```
nginx: [emerg] invalid value "must-revalidate" in /etc/nginx/conf.d/default.conf:13
```

## Root Cause
The `gzip_proxied` directive in `frontend/nginx.conf` contains an invalid value `must-revalidate`:
```nginx
gzip_proxied expired no-cache no-store private must-revalidate auth;
```

The `must-revalidate` value is not valid for the `gzip_proxied` directive in nginx.

## Solution
Removed the invalid `must-revalidate` value from the `gzip_proxied` directive:
```nginx
gzip_proxied expired no-cache no-store private auth;
```

## Impact
- ✅ Frontend container will start successfully
- ✅ No more continuous restart loop
- ✅ Production deployment will work properly
- ✅ No breaking changes to functionality

## Testing
After applying this fix and rebuilding the frontend container:
```bash
docker compose -f docker-compose.prod.yml build frontend
docker compose -f docker-compose.prod.yml up -d frontend
```

The frontend should start successfully without nginx errors.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update