### PR TITLE
fix: Replace npm ci with npm install in backend Dockerfile for workspace compatibility

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -31,7 +31,7 @@ CMD ["npm", "run", "dev"]
 FROM base AS builder
 
 # Install dependencies (including dev dependencies for build)
-RUN npm ci && npm cache clean --force
+RUN npm install && npm cache clean --force
 
 # Copy source code
 COPY . .
@@ -58,7 +58,7 @@ WORKDIR /app
 COPY package*.json ./
 
 # Install only production dependencies
-RUN npm ci --only=production && npm cache clean --force
+RUN npm install --only=production && npm cache clean --force
 
 # Copy built application from builder stage
 COPY --from=builder /app/dist ./dist


### PR DESCRIPTION
## Problem
The deployment pipeline was failing because the backend Dockerfile was using `npm ci` which requires a `package-lock.json` file in the backend directory.

## Root Cause
This is a workspace setup with a root-level `package-lock.json` file. Individual workspaces (backend, frontend, e2e-tests) don't have their own lock files, which is the standard npm workspace pattern.

## Solution
- Changed backend Dockerfile from `npm ci` to `npm install` in both builder and production stages
- This allows the Docker build to work without requiring individual package-lock.json files
- Frontend Dockerfile was already using `npm install` so no changes needed there

## Testing
- Local Docker build should now work correctly
- Production deployment should complete successfully
- No functional changes to the application

## Impact
- Fixes critical deployment pipeline failure
- Maintains workspace compatibility
- No breaking changes to existing functionality

Resolves the deployment failure seen in the production pipeline where Docker build was failing with:
```
npm error The `npm ci` command can only install with an existing package-lock.json
```