### PR TITLE
Fix frontend API URL build argument issue

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -111,7 +111,7 @@ jobs:
             docker-compose -f docker-compose.prod.yml build --no-cache backend
             
             echo "📦 Building frontend..."
-            docker-compose -f docker-compose.prod.yml build --no-cache frontend
+            docker-compose -f docker-compose.prod.yml build --no-cache --build-arg VITE_API_URL="$VITE_API_URL" frontend
             
             echo "📦 Building remaining services..."
             docker-compose -f docker-compose.prod.yml build --no-cache nginx

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -130,6 +130,8 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile.prod
+      args:
+        VITE_API_URL: ${VITE_API_URL}
     container_name: family-board-frontend
     ports:
       - "3000:80"


### PR DESCRIPTION
## 🐛 Problem

The frontend was built with `localhost:3001` as the API URL instead of the production domain `http://mabt.eu`, causing authentication failures in production.

## 🔍 Root Cause

- Vite environment variables are processed at **build time**, not runtime
- The Docker build process wasn't receiving the `VITE_API_URL` build argument
- When missing, Vite defaults to the fallback localhost URL

## 🛠️ Solution

### 1. Updated `docker-compose.prod.yml`
- Added `VITE_API_URL` build argument to frontend service

### 2. Updated deployment workflow
- Pass `VITE_API_URL` build argument during frontend Docker build

## ✅ Expected Results

- Frontend will be built with correct API URL (`http://mabt.eu`)
- Authentication will work properly through production domain
- All API calls will target production backend instead of localhost
- Resolves "Invalid email or password" errors

## 🧪 Testing

Backend API already confirmed working via direct curl tests:
```bash
curl -X POST http://mabt.eu/api/auth/login \
  -H 'Content-Type: application/json' \
  -d '{"email":"sami.touil@gmail.com","password":"co2h2o"}'
# Returns: {"success":true,"data":{...}}
```

This PR ensures the frontend uses the same working API endpoint.