### PR TITLE
🚨 HOTFIX: Fix SSL deployment failure

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -178,18 +178,19 @@ services:
       - ssl-setup
     command: certonly --webroot --webroot-path=/var/www/certbot --email ${SSL_EMAIL} --agree-tos --no-eff-email -d mabt.eu -d www.mabt.eu
 
-  # Nginx reverse proxy with SSL support
+  # Nginx reverse proxy (HTTP-only for initial deployment)
   nginx:
     image: nginx:alpine
     container_name: family-board-nginx
     ports:
       - "80:80"
-      - "443:443"
+      # - "443:443"  # Commented out until SSL is set up
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
-      - certbot-etc:/etc/letsencrypt:ro
-      - certbot-var:/var/lib/letsencrypt:ro
-      - web-root:/var/www/certbot:ro
+      # SSL volumes commented out until SSL is set up
+      # - certbot-etc:/etc/letsencrypt:ro
+      # - certbot-var:/var/lib/letsencrypt:ro
+      # - web-root:/var/www/certbot:ro
     depends_on:
       - frontend
       - backend

--- a/nginx/nginx-ssl.conf
+++ b/nginx/nginx-ssl.conf
@@ -53,7 +53,7 @@ http {
     limit_req_zone $binary_remote_addr zone=api:10m rate=10r/s;
     limit_req_zone $binary_remote_addr zone=login:10m rate=5r/m;
     
-    # HTTP server
+    # HTTP server - redirect to HTTPS
     server {
         listen 80;
         server_name mabt.eu www.mabt.eu;
@@ -64,11 +64,43 @@ http {
             try_files $uri =404;
         }
         
-        # Security headers (basic)
+        # Redirect all other HTTP traffic to HTTPS
+        location / {
+            return 301 https://$server_name$request_uri;
+        }
+    }
+    
+    # HTTPS server
+    server {
+        listen 443 ssl http2;
+        server_name mabt.eu www.mabt.eu;
+        
+        # SSL configuration
+        ssl_certificate /etc/letsencrypt/live/mabt.eu/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/mabt.eu/privkey.pem;
+        
+        # SSL security settings
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384;
+        ssl_prefer_server_ciphers off;
+        ssl_session_cache shared:SSL:10m;
+        ssl_session_timeout 10m;
+        ssl_session_tickets off;
+        
+        # OCSP stapling
+        ssl_stapling on;
+        ssl_stapling_verify on;
+        ssl_trusted_certificate /etc/letsencrypt/live/mabt.eu/chain.pem;
+        resolver 8.8.8.8 8.8.4.4 valid=300s;
+        resolver_timeout 5s;
+        
+        # Security headers
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-XSS-Protection "1; mode=block" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' wss: ws:;" always;
         
         # API routes with rate limiting
         location /api/ {


### PR DESCRIPTION
## 🚨 Critical Deployment Fix

This hotfix resolves the deployment failure caused by the SSL configuration trying to load certificates that don't exist yet.

### 🐛 Problem
- Deployment failing with health check errors
- Nginx trying to load SSL certificates that haven't been created yet
- SSL configuration preventing successful startup

### ✅ Solution
- Replace SSL-enabled nginx config with HTTP-only version
- Comment out SSL volumes in docker-compose.prod.yml
- Remove port 443 binding until SSL certificates are available
- Backup original SSL config as nginx-ssl.conf

### 🚀 Impact
- ✅ Fixes immediate deployment failure
- ✅ Allows application to start successfully over HTTP
- ✅ Preserves SSL configuration for later setup
- ✅ Maintains all existing functionality

### 📋 Next Steps (After Merge)
1. Deploy will succeed with HTTP-only configuration
2. SSL can be added later using the provided setup scripts:
   - `./scripts/setup-ssl.sh` for initial SSL setup
   - `./scripts/setup-ssl-renewal.sh` for automatic renewal
3. Switch to `nginx-ssl.conf` after SSL certificates are in place

This is a critical fix needed to restore production deployment functionality.