### PR TITLE
Fix: Enable SSL/HTTPS support in production

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -178,19 +178,18 @@ services:
       - ssl-setup
     command: certonly --webroot --webroot-path=/var/www/certbot --email ${SSL_EMAIL} --agree-tos --no-eff-email -d mabt.eu -d www.mabt.eu
 
-  # Nginx reverse proxy (HTTP-only for initial deployment)
+  # Nginx reverse proxy with SSL support
   nginx:
     image: nginx:alpine
     container_name: family-board-nginx
     ports:
       - "80:80"
-      # - "443:443"  # Commented out until SSL is set up
+      - "443:443"
     volumes:
-      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
-      # SSL volumes commented out until SSL is set up
-      # - certbot-etc:/etc/letsencrypt:ro
-      # - certbot-var:/var/lib/letsencrypt:ro
-      # - web-root:/var/www/certbot:ro
+      - ./nginx/nginx-ssl.conf:/etc/nginx/nginx.conf:ro
+      - certbot-etc:/etc/letsencrypt:ro
+      - certbot-var:/var/lib/letsencrypt:ro
+      - web-root:/var/www/certbot:ro
     depends_on:
       - frontend
       - backend


### PR DESCRIPTION
## 🔒 SSL/HTTPS Production Fix

### Problem
The production server was manually configured with SSL certificates and HTTPS, but the source repository still had HTTP-only configuration. When the CD pipeline deployed, it overwrote the manual SSL setup, breaking HTTPS access.

### Solution
- ✅ Enable port 443 in nginx service
- ✅ Mount SSL certificate volumes (certbot-etc, certbot-var, web-root)
- ✅ Use nginx-ssl.conf with proper HTTPS redirect and SSL configuration
- ✅ Maintain existing SSL certificates and setup

### Changes
- Updated `docker-compose.prod.yml` to enable SSL support
- Changed nginx configuration from `nginx.conf` to `nginx-ssl.conf`
- Uncommented port 443 and SSL volume mounts

### Testing
This will restore HTTPS functionality to https://mabt.eu with proper SSL certificates.

### Impact
- 🔒 Restores HTTPS access to production
- 🚀 Maintains existing SSL certificates
- 🔄 Prevents future deployments from breaking SSL
- ✅ No downtime expected (certificates already exist)