### PR TITLE
fix: WebSocket connection stability improvements

### DIFF
--- a/backend/src/middleware/csrf.middleware.ts
+++ b/backend/src/middleware/csrf.middleware.ts
@@ -111,8 +111,8 @@ export function validateCSRFToken(
     return;
   }
 
-  // Skip validation for health check and auth endpoints that don't need CSRF
-  const skipPaths = ['/api/health', '/api/auth/login', '/api/auth/signup'];
+  // Skip validation for health check, auth endpoints, and WebSocket connections
+  const skipPaths = ['/api/health', '/api/auth/login', '/api/auth/signup', '/socket.io/'];
   if (skipPaths.some(path => req.path.startsWith(path))) {
     next();
     return;

--- a/frontend/src/contexts/WebSocketContext.tsx
+++ b/frontend/src/contexts/WebSocketContext.tsx
@@ -91,6 +91,13 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
       transports: ['websocket', 'polling'],
       timeout: 20000,
       forceNew: true,
+      upgrade: true,
+      rememberUpgrade: true,
+      autoConnect: true,
+      reconnection: true,
+      reconnectionAttempts: 5,
+      reconnectionDelay: 1000,
+      reconnectionDelayMax: 5000,
     });
 
     // Connection event handlers
@@ -114,12 +121,17 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
       }
     });
 
-    newSocket.on('connect_error', () => {
+    newSocket.on('connect_error', (error) => {
+      console.error('WebSocket connection error:', error);
       setIsConnected(false);
-      
+
       if (reconnectAttempts.current < maxReconnectAttempts) {
         scheduleReconnect();
       }
+    });
+
+    newSocket.on('error', (error) => {
+      console.error('WebSocket error:', error);
     });
 
     // Real-time event handlers

--- a/nginx/nginx-ssl.conf
+++ b/nginx/nginx-ssl.conf
@@ -5,12 +5,18 @@ events {
 http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
-    
+
+    # WebSocket connection upgrade mapping
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        '' close;
+    }
+
     # Logging
     log_format main '$remote_addr - $remote_user [$time_local] "$request" '
                     '$status $body_bytes_sent "$http_referer" '
                     '"$http_user_agent" "$http_x_forwarded_for"';
-    
+
     access_log /var/log/nginx/access.log main;
     error_log /var/log/nginx/error.log warn;
     
@@ -149,10 +155,17 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
-            
+
             # WebSocket timeouts
             proxy_read_timeout 86400s;
             proxy_send_timeout 86400s;
+            proxy_connect_timeout 60s;
+
+            # Disable buffering for WebSocket
+            proxy_buffering off;
+
+            # Handle WebSocket connection upgrades properly
+            proxy_set_header Connection $connection_upgrade;
         }
         
         # Health check endpoint


### PR DESCRIPTION
## 🔧 WebSocket Connection Fixes

This PR resolves WebSocket connection failures that were causing errors like:
`WebSocket connection to 'wss://mabt.eu/socket.io/' failed: The network connection was lost.`

### 🛠️ Changes Made

**Backend:**
- Exclude WebSocket connections (`/socket.io/`) from CSRF validation
- WebSockets use JWT authentication, so CSRF tokens are not needed

**Nginx Configuration:**
- Add proper WebSocket upgrade mapping
- Improve proxy configuration for WebSocket connections
- Add connection timeout and buffering optimizations

**Frontend:**
- Enhanced Socket.IO client configuration with better reconnection logic
- Added proper error handling and logging
- Improved connection resilience

### 🧪 Testing

- WebSocket connections should now establish successfully
- Real-time notifications should work properly
- Fallback to polling transport if WebSocket fails

### 🔒 Security

- CSRF protection remains active for all API endpoints
- WebSocket authentication still uses JWT tokens
- No security compromises made

Fixes the WebSocket connectivity issues while maintaining all security measures.