### PR TITLE
feat: Add CSRF status endpoint to fix 404 error

### DIFF
--- a/backend/src/routes/csrf.routes.ts
+++ b/backend/src/routes/csrf.routes.ts
@@ -4,9 +4,27 @@ import { generateCSRFToken, getCSRFToken } from '../middleware/csrf.middleware';
 const router = Router();
 
 /**
+ * CSRF Status endpoint
+ * GET /api/csrf/status
+ *
+ * This endpoint allows client applications to check if CSRF protection
+ * is currently enabled or disabled on the server.
+ */
+router.get('/status', (req, res) => {
+  const isEnabled = process.env['DISABLE_CSRF_VALIDATION'] !== 'true';
+
+  res.json({
+    enabled: isEnabled,
+    message: isEnabled
+      ? 'CSRF protection is enabled'
+      : 'CSRF protection is disabled'
+  });
+});
+
+/**
  * CSRF Token endpoint
  * GET /api/csrf/token
- * 
+ *
  * This endpoint allows client applications to retrieve a CSRF token.
  * The token is automatically generated and set as a cookie, and also
  * returned in the response body for client-side use.


### PR DESCRIPTION
## 🔧 CSRF Status Endpoint

This PR adds the missing CSRF status endpoint that was causing 404 errors in production.

### 🛠️ Changes Made

**New Endpoint Added:**
- `GET /api/csrf/status` - Check if CSRF protection is enabled/disabled

**Response Format:**
```json
{
  "enabled": true/false,
  "message": "CSRF protection is enabled/disabled"
}
```

**TypeScript Fixes:**
- Fixed compilation errors in CSRF integration tests
- Removed unused imports and parameters
- Added proper type safety for optional properties

### 🧪 Testing

**✅ Local Testing:**
```bash
# CSRF status endpoint
curl http://localhost:3001/api/csrf/status
# Returns: {"enabled":false,"message":"CSRF protection is disabled"}

# CSRF token endpoint (still works)
curl http://localhost:3001/api/csrf/token  
# Returns: {"success":true,"csrfToken":"..."}
```

**✅ Available Endpoints:**
- `/api/csrf/status` - Check CSRF protection status ✅ NEW
- `/api/csrf/token` - Get CSRF token ✅ EXISTING

### 🔒 Security

- No security changes to existing CSRF protection
- Status endpoint only reveals if protection is enabled/disabled
- No sensitive information exposed

### 🎯 Fixes

- ✅ Resolves 404 error for `test-csrf-check` requests
- ✅ Provides proper CSRF status endpoint for client applications
- ✅ Maintains all existing CSRF functionality

This should eliminate the 404 errors you were seeing in production for CSRF status checks.