### PR TITLE
fix: Configure backend to use root .env file in monorepo

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
-    "dev": "tsx watch src/index.ts",
+    "dev": "dotenv -e ../.env -- tsx watch src/index.ts",
     "start": "node dist/index.js",
     "test": "npm run test:unit",
     "test:all": "npm run test:unit && npm run test:integration",
@@ -15,13 +15,13 @@
     "test:coverage": "jest --config=jest.unit.config.js --coverage",
     "lint": "eslint src --ext .ts",
     "lint:fix": "eslint src --ext .ts --fix",
-    "prisma:generate": "prisma generate",
-    "prisma:migrate": "prisma migrate dev",
-    "prisma:studio": "prisma studio",
-    "prisma:seed": "tsx src/prisma/seed.ts",
-    "db:export": "tsx scripts/export-db.ts",
-    "db:reset-with-seed": "prisma db push --force-reset && npm run prisma:seed",
-    "db:safe-push": "npm run db:export && prisma db push && npm run prisma:seed"
+    "prisma:generate": "dotenv -e ../.env -- prisma generate",
+    "prisma:migrate": "dotenv -e ../.env -- prisma migrate dev",
+    "prisma:studio": "dotenv -e ../.env -- prisma studio",
+    "prisma:seed": "dotenv -e ../.env -- tsx src/prisma/seed.ts",
+    "db:export": "dotenv -e ../.env -- tsx scripts/export-db.ts",
+    "db:reset-with-seed": "dotenv -e ../.env -- prisma db push --force-reset && npm run prisma:seed",
+    "db:safe-push": "npm run db:export && dotenv -e ../.env -- prisma db push && npm run prisma:seed"
   },
   "dependencies": {
     "@prisma/client": "^5.19.1",
@@ -49,6 +49,7 @@
     "@types/supertest": "^2.0.16",
     "@typescript-eslint/eslint-plugin": "^6.13.1",
     "@typescript-eslint/parser": "^6.13.1",
+    "dotenv-cli": "^8.0.0",
     "eslint": "^8.54.0",
     "jest": "^29.7.0",
     "prisma": "^5.7.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "@types/supertest": "^2.0.16",
         "@typescript-eslint/eslint-plugin": "^6.13.1",
         "@typescript-eslint/parser": "^6.13.1",
+        "dotenv-cli": "^8.0.0",
         "eslint": "^8.54.0",
         "jest": "^29.7.0",
         "prisma": "^5.7.1",
@@ -4655,6 +4656,45 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-cli": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-cli/-/dotenv-cli-8.0.0.tgz",
+      "integrity": "sha512-aLqYbK7xKOiTMIRf1lDPbI+Y+Ip/wo5k3eyp6ePysVaSqbyxjyK3dK35BTxG+rmd7djf5q2UPs4noPNH+cj0Qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "dotenv": "^16.3.0",
+        "dotenv-expand": "^10.0.0",
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "dotenv": "cli.js"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
+      "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -8224,6 +8264,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/mlly": {


### PR DESCRIPTION
## Summary
- Fixes `npm run db:reset` command failing due to missing DATABASE_URL environment variable
- Configures backend to use the root `.env` file instead of requiring a separate backend `.env`
- Maintains single source of truth for environment variables in the monorepo

## Changes
- Added `dotenv-cli` as a dev dependency to the backend
- Updated all backend npm scripts that require environment variables to use `dotenv -e ../.env --` prefix
- This ensures Prisma and other tools can access the DATABASE_URL and other environment variables from the root `.env` file

## Test plan
- [x] Run `docker-compose up -d postgres` to start the database
- [x] Run `npm run db:reset` from the root directory
- [x] Verify the command completes successfully without environment variable errors
- [x] Verify the database is seeded with the exported data

🤖 Generated with [Claude Code](https://claude.ai/code)