### PR TITLE
feat: Add shift visualization for sequential tasks in weekly calendar

### DIFF
--- a/frontend/src/components/calendar/WeeklyCalendar.css
+++ b/frontend/src/components/calendar/WeeklyCalendar.css
@@ -224,6 +224,95 @@
   gap: 0.75rem;
 }
 
+/* Shift Visualization */
+.weekly-calendar-shift {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.weekly-calendar-shift.is-multi-task {
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.05) 0%, rgba(168, 85, 247, 0.05) 100%);
+  border: 2px solid rgba(99, 102, 241, 0.2);
+  border-radius: 12px;
+  padding: 0.75rem;
+  box-shadow: 0 2px 4px rgba(99, 102, 241, 0.1);
+  transition: all 0.2s ease;
+  position: relative;
+}
+
+.weekly-calendar-shift.is-multi-task::before {
+  content: '';
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  right: -2px;
+  bottom: -2px;
+  background: linear-gradient(135deg, #6366f1 0%, #a855f7 100%);
+  border-radius: 12px;
+  opacity: 0;
+  z-index: -1;
+  transition: opacity 0.2s ease;
+}
+
+.weekly-calendar-shift.is-multi-task:hover {
+  border-color: rgba(99, 102, 241, 0.3);
+  box-shadow: 0 4px 8px rgba(99, 102, 241, 0.15);
+  transform: translateY(-1px);
+}
+
+.weekly-calendar-shift.is-multi-task:hover::before {
+  opacity: 0.1;
+}
+
+.weekly-calendar-shift-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding-bottom: 0.5rem;
+  margin-bottom: 0.5rem;
+  border-bottom: 1px dashed rgba(99, 102, 241, 0.2);
+}
+
+.weekly-calendar-shift-member-name {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #4c51bf;
+}
+
+.weekly-calendar-shift-tasks {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.weekly-calendar-shift-tasks.grouped .task-override-card {
+  margin: 0;
+  box-shadow: none;
+  border: 1px solid rgba(0, 0, 0, 0.05);
+}
+
+.weekly-calendar-shift-tasks.grouped .task-override-card:not(:last-child) {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  margin-bottom: -1px;
+}
+
+.weekly-calendar-shift-tasks.grouped .task-override-card:not(:first-child) {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.weekly-calendar-shift-tasks.grouped .task-override-card-actions {
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.weekly-calendar-shift:hover .task-override-card-actions {
+  opacity: 1;
+}
+
 /* Add Task Button */
 .weekly-calendar-day-add-task {
   width: 100%;
@@ -297,6 +386,18 @@
   
   .weekly-calendar-tasks-lane {
     padding: 0.75rem;
+  }
+  
+  .weekly-calendar-shift.is-multi-task {
+    padding: 0.5rem;
+  }
+  
+  .weekly-calendar-shift-header {
+    font-size: 0.8125rem;
+  }
+  
+  .weekly-calendar-shift-member-name {
+    font-size: 0.8125rem;
   }
   
   /* Task styles removed - now handled by TaskOverrideCard.css */

--- a/frontend/src/components/calendar/WeeklyCalendar.tsx
+++ b/frontend/src/components/calendar/WeeklyCalendar.tsx
@@ -726,6 +726,7 @@ export const WeeklyCalendar: React.FC<WeeklyCalendarProps> = ({ className }) => 
                                   formatDuration={formatDuration}
                                   showDescription={false}
                                   compact={false}
+                                  hideAvatar={isMultiTaskShift}
                                 />
                               ))}
                             </div>

--- a/frontend/src/components/calendar/WeeklyCalendar.tsx
+++ b/frontend/src/components/calendar/WeeklyCalendar.tsx
@@ -3,7 +3,7 @@ import { useFamily } from '../../contexts/FamilyContext';
 import { weekScheduleApi, weekTemplateApi, dayTemplateApi, taskApi } from '../../services/api';
 import { apiClient } from '../../services/api-client';
 import { LoadingSpinner } from '../ui/LoadingSpinner';
-import { TaskOverrideCard, Button } from '../ui';
+import { TaskOverrideCard, Button, UserAvatar } from '../ui';
 import { TaskOverrideModal } from './TaskOverrideModal';
 import type { ResolvedWeekSchedule, ResolvedTask, WeekTemplate, DayTemplate, DayTemplateItem, Task, User, CreateTaskOverrideData } from '../../types';
 import './WeeklyCalendar.css';
@@ -508,6 +508,30 @@ export const WeeklyCalendar: React.FC<WeeklyCalendarProps> = ({ className }) => 
     return sortTasksByTime(day.tasks);
   };
 
+  // Group sequential tasks by member into shifts
+  const groupTasksIntoShifts = (tasks: ResolvedTask[]): Array<{ memberId: string | null; tasks: ResolvedTask[] }> => {
+    if (tasks.length === 0) return [];
+    
+    const shifts: Array<{ memberId: string | null; tasks: ResolvedTask[] }> = [];
+    let currentShift: { memberId: string | null; tasks: ResolvedTask[] } | null = null;
+    
+    tasks.forEach((task) => {
+      if (!currentShift || currentShift.memberId !== task.memberId) {
+        // Start a new shift
+        currentShift = {
+          memberId: task.memberId,
+          tasks: [task]
+        };
+        shifts.push(currentShift);
+      } else {
+        // Add to current shift
+        currentShift.tasks.push(task);
+      }
+    });
+    
+    return shifts;
+  };
+
   const isCurrentWeek = (): boolean => {
     const today = new Date();
     const currentMonday = getMonday(today);
@@ -667,20 +691,47 @@ export const WeeklyCalendar: React.FC<WeeklyCalendarProps> = ({ className }) => 
                     </div>
                   ) : (
                     <div className="weekly-calendar-tasks-stack">
-                      {dayTasks.map((task, taskIndex) => (
-                        <TaskOverrideCard
-                          key={`${task.taskId}-${task.memberId}-${taskIndex}`}
-                          task={task}
-                          taskIndex={taskIndex}
-                          isAdmin={isAdmin}
-                          onRemove={(task) => handleTaskOverride('REMOVE', task, day.date)}
-                          onReassign={(task) => handleTaskOverride('REASSIGN', task, day.date)}
-                          formatTime={formatTime}
-                          formatDuration={formatDuration}
-                          showDescription={false}
-                          compact={false}
-                        />
-                      ))}
+                      {groupTasksIntoShifts(dayTasks).map((shift, shiftIndex) => {
+                        const isMultiTaskShift = shift.tasks.length > 1;
+                        const shiftMember = shift.tasks[0]?.member;
+                        
+                        return (
+                          <div
+                            key={`shift-${shiftIndex}-${shift.memberId}`}
+                            className={`weekly-calendar-shift ${isMultiTaskShift ? 'is-multi-task' : ''}`}
+                          >
+                            {isMultiTaskShift && shiftMember && (
+                              <div className="weekly-calendar-shift-header">
+                                <UserAvatar
+                                  firstName={shiftMember.firstName}
+                                  lastName={shiftMember.lastName}
+                                  avatarUrl={shiftMember.avatarUrl}
+                                  size="extra-small"
+                                />
+                                <span className="weekly-calendar-shift-member-name">
+                                  {shiftMember.firstName}'s shift ({shift.tasks.length} tasks)
+                                </span>
+                              </div>
+                            )}
+                            <div className={`weekly-calendar-shift-tasks ${isMultiTaskShift ? 'grouped' : ''}`}>
+                              {shift.tasks.map((task, taskIndex) => (
+                                <TaskOverrideCard
+                                  key={`${task.taskId}-${task.memberId}-${taskIndex}`}
+                                  task={task}
+                                  taskIndex={taskIndex}
+                                  isAdmin={isAdmin}
+                                  onRemove={(task) => handleTaskOverride('REMOVE', task, day.date)}
+                                  onReassign={(task) => handleTaskOverride('REASSIGN', task, day.date)}
+                                  formatTime={formatTime}
+                                  formatDuration={formatDuration}
+                                  showDescription={false}
+                                  compact={false}
+                                />
+                              ))}
+                            </div>
+                          </div>
+                        );
+                      })}
                     </div>
                   )}
                   

--- a/frontend/src/components/ui/TaskOverrideCard.tsx
+++ b/frontend/src/components/ui/TaskOverrideCard.tsx
@@ -15,6 +15,7 @@ interface TaskOverrideCardProps {
   formatDuration: (minutes: number) => string;
   showDescription?: boolean;
   compact?: boolean;
+  hideAvatar?: boolean;
 }
 
 export const TaskOverrideCard: React.FC<TaskOverrideCardProps> = ({
@@ -27,7 +28,8 @@ export const TaskOverrideCard: React.FC<TaskOverrideCardProps> = ({
   formatTime,
   formatDuration,
   showDescription = true,
-  compact = false
+  compact = false,
+  hideAvatar = false
 }) => {
   const startTime = task.overrideTime || task.task.defaultStartTime;
   const duration = task.overrideDuration || task.task.defaultDuration;
@@ -57,7 +59,7 @@ export const TaskOverrideCard: React.FC<TaskOverrideCardProps> = ({
           </div>
         </div>
         
-        {task.member && (
+        {task.member && !hideAvatar && (
           <div className="task-override-card-member">
             <UserAvatar
               firstName={task.member.firstName}


### PR DESCRIPTION
## Summary
- Enhances the weekly schedule visualization by grouping sequential tasks assigned to the same family member
- Creates a visual "shift" representation with an outline around grouped tasks
- Improves the user experience by making it easier to see work patterns and task assignments

## Changes
### Component Logic (WeeklyCalendar.tsx)
- Added `groupTasksIntoShifts` function to detect and group consecutive tasks by member
- Modified task rendering to wrap shifts in a container div
- Added shift header showing member avatar and task count for multi-task shifts
- Pass `hideAvatar` prop to TaskOverrideCard for grouped tasks

### TaskOverrideCard Component
- Added `hideAvatar` prop to conditionally hide the member avatar
- Prevents redundant avatar display when already shown in shift header

### Visual Design (WeeklyCalendar.css)
- Added `.weekly-calendar-shift` container with gradient background and border
- Created visual connection between tasks in the same shift
- Added hover effects and smooth transitions
- Implemented responsive design adjustments for mobile views

## Visual Features
- **Shift Container**: Multi-task shifts are wrapped in a subtle purple gradient box
- **Shift Header**: Shows the assigned member's avatar and name with task count
- **Connected Cards**: Task cards within a shift have connected borders (avatars hidden to avoid redundancy)
- **Hover Effects**: Enhanced visibility when hovering over a shift
- **Mobile Friendly**: Responsive adjustments for smaller screens

## Test plan
- [x] View weekly calendar with multiple sequential tasks assigned to the same person
- [x] Verify shift visualization appears with proper outline and header
- [x] Test hover effects on shift containers
- [x] Check single tasks (no shift visualization should appear)
- [x] Test on mobile viewport to ensure responsive design works
- [x] Verify admin controls still function properly within shifts
- [x] Confirm avatars are hidden in task cards within shifts
- [x] Verify avatars still appear for single tasks not in shifts

🤖 Generated with [Claude Code](https://claude.ai/code)