### PR TITLE
feat: Enhance shift header with time range and duration tags

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@ DB_NAME=family_board
 DB_USER=postgres
 DB_PASSWORD=postgres
 DB_PORT=5432
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/family_board
 
 BACKEND_PORT=3001
 JWT_SECRET=your-super-secret-jwt-key-must-be-at-least-32-characters-long-change-this-in-production

--- a/frontend/src/components/calendar/WeeklyCalendar.css
+++ b/frontend/src/components/calendar/WeeklyCalendar.css
@@ -275,10 +275,37 @@
   border-bottom: 1px dashed rgba(99, 102, 241, 0.2);
 }
 
-.weekly-calendar-shift-member-name {
-  font-size: 0.875rem;
-  font-weight: 600;
-  color: #4c51bf;
+.weekly-calendar-shift-tags {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.25rem;
+  flex: 1;
+}
+
+.weekly-calendar-shift-tag {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.75rem;
+  font-weight: 500;
+  padding: 0.125rem 0.375rem;
+  border-radius: 6px;
+  border: 1px solid;
+  transition: all 0.2s ease;
+  white-space: nowrap;
+  line-height: 1.3;
+}
+
+.weekly-calendar-shift-tag.time-tag {
+  background-color: #eff6ff;
+  border-color: #bfdbfe;
+  color: #1e40af;
+}
+
+.weekly-calendar-shift-tag.duration-tag {
+  background-color: #f0fdf4;
+  border-color: #bbf7d0;
+  color: #166534;
 }
 
 .weekly-calendar-shift-tasks {
@@ -396,8 +423,9 @@
     font-size: 0.8125rem;
   }
   
-  .weekly-calendar-shift-member-name {
-    font-size: 0.8125rem;
+  .weekly-calendar-shift-tag {
+    font-size: 0.6875rem;
+    padding: 0.0625rem 0.25rem;
   }
   
   /* Task styles removed - now handled by TaskOverrideCard.css */

--- a/frontend/src/components/calendar/WeeklyCalendar.tsx
+++ b/frontend/src/components/calendar/WeeklyCalendar.tsx
@@ -708,24 +708,32 @@ export const WeeklyCalendar: React.FC<WeeklyCalendarProps> = ({ className }) => 
                         if (isMultiTaskShift && shift.tasks.length > 0) {
                           // Get start time from first task
                           const firstTask = shift.tasks[0];
-                          shiftStartTime = firstTask.overrideTime || firstTask.task.defaultStartTime;
-                          
-                          // Calculate end time from last task
-                          const lastTask = shift.tasks[shift.tasks.length - 1];
-                          const lastTaskStartTime = lastTask.overrideTime || lastTask.task.defaultStartTime;
-                          const lastTaskDuration = lastTask.overrideDuration || lastTask.task.defaultDuration;
-                          
-                          // Parse time and add duration
-                          const [lastHours, lastMinutes] = lastTaskStartTime.split(':').map(Number);
-                          const endMinutes = lastHours * 60 + lastMinutes + lastTaskDuration;
-                          const endHours = Math.floor(endMinutes / 60);
-                          const endMins = endMinutes % 60;
-                          shiftEndTime = `${String(endHours).padStart(2, '0')}:${String(endMins).padStart(2, '0')}`;
-                          
-                          // Calculate total duration from first task start to last task end
-                          const [firstHours, firstMinutes] = shiftStartTime.split(':').map(Number);
-                          const startTotalMinutes = firstHours * 60 + firstMinutes;
-                          totalDuration = endMinutes - startTotalMinutes;
+                          if (firstTask) {
+                            shiftStartTime = firstTask.overrideTime || firstTask.task.defaultStartTime;
+                            
+                            // Calculate end time from last task
+                            const lastTask = shift.tasks[shift.tasks.length - 1];
+                            if (lastTask) {
+                              const lastTaskStartTime = lastTask.overrideTime || lastTask.task.defaultStartTime;
+                              const lastTaskDuration = lastTask.overrideDuration || lastTask.task.defaultDuration;
+                              
+                              // Parse time and add duration
+                              const lastTimeParts = lastTaskStartTime.split(':').map(Number);
+                              const lastHours = lastTimeParts[0] || 0;
+                              const lastMinutes = lastTimeParts[1] || 0;
+                              const endMinutes = lastHours * 60 + lastMinutes + lastTaskDuration;
+                              const endHours = Math.floor(endMinutes / 60);
+                              const endMins = endMinutes % 60;
+                              shiftEndTime = `${String(endHours).padStart(2, '0')}:${String(endMins).padStart(2, '0')}`;
+                              
+                              // Calculate total duration from first task start to last task end
+                              const firstTimeParts = shiftStartTime.split(':').map(Number);
+                              const firstHours = firstTimeParts[0] || 0;
+                              const firstMinutes = firstTimeParts[1] || 0;
+                              const startTotalMinutes = firstHours * 60 + firstMinutes;
+                              totalDuration = endMinutes - startTotalMinutes;
+                            }
+                          }
                         }
                         
                         return (

--- a/frontend/src/components/calendar/WeeklyCalendar.tsx
+++ b/frontend/src/components/calendar/WeeklyCalendar.tsx
@@ -494,6 +494,11 @@ export const WeeklyCalendar: React.FC<WeeklyCalendarProps> = ({ className }) => 
     return `${displayHour}:${minutes || '00'} ${ampm}`;
   };
 
+  const formatTime24 = (time: string): string => {
+    const [hours, minutes] = time.split(':');
+    return `${hours || '00'}:${minutes || '00'}`;
+  };
+
   const formatDuration = (minutes: number): string => {
     if (minutes < 60) {
       return `${minutes}m`;
@@ -695,6 +700,34 @@ export const WeeklyCalendar: React.FC<WeeklyCalendarProps> = ({ className }) => 
                         const isMultiTaskShift = shift.tasks.length > 1;
                         const shiftMember = shift.tasks[0]?.member;
                         
+                        // Calculate shift time range and duration
+                        let shiftStartTime = '';
+                        let shiftEndTime = '';
+                        let totalDuration = 0;
+                        
+                        if (isMultiTaskShift && shift.tasks.length > 0) {
+                          // Get start time from first task
+                          const firstTask = shift.tasks[0];
+                          shiftStartTime = firstTask.overrideTime || firstTask.task.defaultStartTime;
+                          
+                          // Calculate end time from last task
+                          const lastTask = shift.tasks[shift.tasks.length - 1];
+                          const lastTaskStartTime = lastTask.overrideTime || lastTask.task.defaultStartTime;
+                          const lastTaskDuration = lastTask.overrideDuration || lastTask.task.defaultDuration;
+                          
+                          // Parse time and add duration
+                          const [lastHours, lastMinutes] = lastTaskStartTime.split(':').map(Number);
+                          const endMinutes = lastHours * 60 + lastMinutes + lastTaskDuration;
+                          const endHours = Math.floor(endMinutes / 60);
+                          const endMins = endMinutes % 60;
+                          shiftEndTime = `${String(endHours).padStart(2, '0')}:${String(endMins).padStart(2, '0')}`;
+                          
+                          // Calculate total duration from first task start to last task end
+                          const [firstHours, firstMinutes] = shiftStartTime.split(':').map(Number);
+                          const startTotalMinutes = firstHours * 60 + firstMinutes;
+                          totalDuration = endMinutes - startTotalMinutes;
+                        }
+                        
                         return (
                           <div
                             key={`shift-${shiftIndex}-${shift.memberId}`}
@@ -706,11 +739,16 @@ export const WeeklyCalendar: React.FC<WeeklyCalendarProps> = ({ className }) => 
                                   firstName={shiftMember.firstName}
                                   lastName={shiftMember.lastName}
                                   avatarUrl={shiftMember.avatarUrl}
-                                  size="extra-small"
+                                  size="small"
                                 />
-                                <span className="weekly-calendar-shift-member-name">
-                                  {shiftMember.firstName}'s shift ({shift.tasks.length} tasks)
-                                </span>
+                                <div className="weekly-calendar-shift-tags">
+                                  <span className="weekly-calendar-shift-tag time-tag">
+                                    {formatTime24(shiftStartTime)} - {formatTime24(shiftEndTime)}
+                                  </span>
+                                  <span className="weekly-calendar-shift-tag duration-tag">
+                                    {formatDuration(totalDuration)}
+                                  </span>
+                                </div>
                               </div>
                             )}
                             <div className={`weekly-calendar-shift-tasks ${isMultiTaskShift ? 'grouped' : ''}`}>


### PR DESCRIPTION
## Summary
- Improves the shift visualization header to display more useful information
- Replaces member name and task count with time-based information
- Provides clearer insight into work periods at a glance

## Changes
### Shift Header Information
- **Time Range Tag**: Shows shift start and end times in 24-hour format (e.g., "08:00 - 12:30")
- **Duration Tag**: Shows total shift duration below the time range (e.g., "4h 30m")
- Removed redundant member name (avatar is sufficient)
- Removed task count (not as useful as time information)

### Visual Improvements
- Tags are stacked vertically for better readability
- Consistent tag styling with TaskOverrideCard (blue for time, green for duration)
- Increased avatar size from "extra-small" to "small" for better visibility
- Added `formatTime24` function for European-style time format

### Technical Details
- Fixed duration calculation to properly account for gaps between tasks
- Duration is now calculated from first task start to last task end
- Added responsive styles for smaller screens

## Visual Example
Before: "John's shift (3 tasks)"
After: 
```
[Avatar] 08:00 - 12:30
         4h 30m
```

## Test plan
- [x] View shifts with multiple sequential tasks
- [x] Verify time range displays correctly in 24-hour format
- [x] Verify duration calculates correctly including gaps between tasks
- [x] Check tag styling matches TaskOverrideCard design
- [x] Test on mobile viewports for responsive behavior
- [x] Ensure single tasks (no shift) display normally

🤖 Generated with [Claude Code](https://claude.ai/code)