### PR TITLE
fix: Improve shift visualization clarity and fix border issue

### DIFF
--- a/frontend/src/components/calendar/WeeklyCalendar.css
+++ b/frontend/src/components/calendar/WeeklyCalendar.css
@@ -317,7 +317,9 @@
 .weekly-calendar-shift-tasks.grouped .task-override-card {
   margin: 0;
   box-shadow: none;
-  border: 1px solid rgba(0, 0, 0, 0.05);
+  border-top: 1px solid rgba(0, 0, 0, 0.05);
+  border-right: 1px solid rgba(0, 0, 0, 0.05);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
 }
 
 .weekly-calendar-shift-tasks.grouped .task-override-card:not(:last-child) {

--- a/frontend/src/components/calendar/WeeklyCalendar.css
+++ b/frontend/src/components/calendar/WeeklyCalendar.css
@@ -233,11 +233,11 @@
 }
 
 .weekly-calendar-shift.is-multi-task {
-  background: linear-gradient(135deg, rgba(99, 102, 241, 0.05) 0%, rgba(168, 85, 247, 0.05) 100%);
-  border: 2px solid rgba(99, 102, 241, 0.2);
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.02) 0%, rgba(168, 85, 247, 0.02) 100%);
+  border: 2px solid rgba(99, 102, 241, 0.15);
   border-radius: 12px;
   padding: 0.75rem;
-  box-shadow: 0 2px 4px rgba(99, 102, 241, 0.1);
+  box-shadow: 0 2px 4px rgba(99, 102, 241, 0.05);
   transition: all 0.2s ease;
   position: relative;
 }
@@ -257,8 +257,8 @@
 }
 
 .weekly-calendar-shift.is-multi-task:hover {
-  border-color: rgba(99, 102, 241, 0.3);
-  box-shadow: 0 4px 8px rgba(99, 102, 241, 0.15);
+  border-color: rgba(99, 102, 241, 0.25);
+  box-shadow: 0 4px 8px rgba(99, 102, 241, 0.1);
   transform: translateY(-1px);
 }
 

--- a/frontend/src/components/ui/TaskOverrideCard.css
+++ b/frontend/src/components/ui/TaskOverrideCard.css
@@ -2,7 +2,7 @@
 .task-override-card {
   background-color: #ffffff;
   border: 1px solid #e5e7eb;
-  border-left: 4px solid #3b82f6;
+  border-left: 6px solid #3b82f6;
   border-radius: 8px;
   padding: 0.75rem;
   transition: all 0.2s ease;
@@ -16,7 +16,7 @@
 
 .task-override-card.is-override {
   border-left-style: dashed;
-  border-left-width: 3px;
+  border-left-width: 6px;
 }
 
 .task-override-card-main {


### PR DESCRIPTION
## Summary
- Improves the visual clarity of shift containers and task cards
- Fixes CSS specificity issue that was hiding the task card left border in shifts
- Ensures task colors are more prominent within shift groupings
- Makes the overall design more subtle while enhancing key visual elements

## Changes
### Shift Background Adjustments
- Reduced background gradient opacity from `0.05` to `0.02` (much more subtle)
- Reduced border opacity from `0.2` to `0.15`
- Reduced box shadow opacity from `0.1` to `0.05`
- Adjusted hover state to match the lighter theme

### Task Card Enhancements
- Increased left border width from `4px` to `6px` for better color visibility
- Applied same width to override tasks (dashed style) for consistency
- **Fixed CSS specificity issue** that was overriding the left border in grouped shifts
- Task colors now stand out more prominently against the subtle shift background

### Bug Fix
- The `.weekly-calendar-shift-tasks.grouped .task-override-card` rule was setting `border: 1px solid ...` which overrode ALL borders including the colored left border
- Changed to only set `border-top`, `border-right`, and `border-bottom` to preserve the left border styling

## Visual Impact
- Task card colors are now more prominent and easier to distinguish
- Left border now correctly shows at 6px width in all views (Home, Tasks, Routines)
- Shift groupings remain visible but don't compete with task colors
- Overall cleaner, more refined appearance
- Better visual hierarchy between container and content

## Test plan
- [x] View shifts with various task colors
- [x] Verify task colors are clearly visible within shift containers
- [x] Check that shift grouping is still apparent but subtle
- [x] Test hover states work correctly
- [x] Ensure override tasks (dashed border) maintain proper width
- [x] Confirm left border shows at 6px in Weekly Schedule (Home page)
- [x] Verify consistent border width across all pages

🤖 Generated with [Claude Code](https://claude.ai/code)