### PR TITLE
fix: Resolve CSRF validation errors in development

### DIFF
--- a/backend/src/middleware/csrf.middleware.ts
+++ b/backend/src/middleware/csrf.middleware.ts
@@ -21,7 +21,7 @@ export interface CSRFRequest extends Request {
  */
 
 const CSRF_TOKEN_LENGTH = 32;
-const CSRF_COOKIE_NAME = '__Host-csrf-token';
+const CSRF_COOKIE_NAME = process.env['NODE_ENV'] === 'production' ? '__Host-csrf-token' : 'csrf-token';
 const CSRF_HEADER_NAME = 'x-csrf-token';
 
 /**

--- a/frontend/src/services/api-client.ts
+++ b/frontend/src/services/api-client.ts
@@ -29,7 +29,7 @@ apiClient.interceptors.request.use(async (config) => {
     if (!isAuthEndpoint) {
       try {
         const csrfToken = await csrfService.getToken();
-        config.headers['X-CSRF-Token'] = csrfToken;
+        config.headers['x-csrf-token'] = csrfToken;
       } catch (error) {
         // Failed to get CSRF token - continue without token
         // Continue with request - server might have CSRF disabled


### PR DESCRIPTION
## Summary
Fixes CSRF token validation errors that occur in local development environment while maintaining security in production.

## Problem
- CSRF validation was failing with "errors.csrfTokenRequired" in local development
- The `__Host-` cookie prefix has strict requirements that don't work well with localhost/HTTP
- Header case sensitivity mismatch between frontend and backend

## Solution
1. **Dynamic cookie naming**:
   - Use `csrf-token` for development (works with HTTP/localhost)
   - Keep `__Host-csrf-token` for production (more secure, requires HTTPS)

2. **Fix header case sensitivity**:
   - Changed frontend to send `x-csrf-token` instead of `X-CSRF-Token`
   - Matches what backend expects

## Changes
- `backend/src/middleware/csrf.middleware.ts`: Dynamic cookie name based on NODE_ENV
- `frontend/src/services/api-client.ts`: Fixed header name to lowercase

## Test plan
- [x] Clear browser cookies for localhost
- [x] Restart backend server
- [x] Test task editing in development - no CSRF errors
- [x] Verify CSRF protection still active (not disabled)
- [x] Confirm production will use secure cookie name

## Security Notes
- CSRF protection remains fully active in all environments
- Production uses more secure `__Host-` prefix with HTTPS
- Development uses simpler name for localhost compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)