### PR TITLE
fix: Implement auto-dismiss functionality for notification messages

### DIFF
--- a/frontend/src/components/calendar/WeeklyCalendar.tsx
+++ b/frontend/src/components/calendar/WeeklyCalendar.tsx
@@ -5,6 +5,7 @@ import { apiClient } from '../../services/api-client';
 import { LoadingSpinner } from '../ui/LoadingSpinner';
 import { TaskOverrideCard, Button, UserAvatar } from '../ui';
 import { TaskOverrideModal } from './TaskOverrideModal';
+import { useMessage } from '../../hooks';
 import type { ResolvedWeekSchedule, ResolvedTask, WeekTemplate, DayTemplate, DayTemplateItem, Task, User, CreateTaskOverrideData } from '../../types';
 import './WeeklyCalendar.css';
 
@@ -21,7 +22,7 @@ export const WeeklyCalendar: React.FC<WeeklyCalendarProps> = ({ className }) => 
   const [currentWeekStart, setCurrentWeekStart] = useState<string>('');
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+  const [message, setMessage] = useMessage();
 
   // Week template application modal state
   const [showApplyTemplateModal, setShowApplyTemplateModal] = useState(false);

--- a/frontend/src/features/auth/components/UserProfile.tsx
+++ b/frontend/src/features/auth/components/UserProfile.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useAuth } from '../../../contexts/AuthContext';
 import { authApi } from '../../../services/api';
 import Modal from '../../../components/ui/Modal';
+import { useMessage } from '../../../hooks';
 import type { ChangePasswordData } from '../../../types';
 import './UserProfile.css';
 
@@ -25,7 +26,7 @@ export const UserProfile: React.FC<UserProfileProps> = ({ onClose }) => {
   const { user, refreshUser } = useAuth();
   
   const [isLoading, setIsLoading] = useState(false);
-  const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+  const [message, setMessage] = useMessage();
 
   // Profile form state
   const [profileData, setProfileData] = useState({

--- a/frontend/src/features/family/components/FamilyManagement.tsx
+++ b/frontend/src/features/family/components/FamilyManagement.tsx
@@ -5,6 +5,7 @@ import { useAuth } from '../../../contexts/AuthContext';
 import { useWebSocket } from '../../../contexts/WebSocketContext';
 import { UserAvatar, RoleTag, CustomSelect, Modal, Button } from '../../../components/ui';
 import { familyApi } from '../../../services/api';
+import { useMessage } from '../../../hooks';
 import type { FamilyMember, FamilyJoinRequest, FamilyInvite, UpdateFamilyData, UpdateVirtualMemberData, CreateVirtualMemberData } from '../../../types';
 import './FamilyManagement.css';
 
@@ -29,7 +30,7 @@ export const FamilyManagement: React.FC = () => {
   const [invites, setInvites] = useState<FamilyInvite[]>([]);
   const [joinRequests, setJoinRequests] = useState<FamilyJoinRequest[]>([]);
   const [isLoading, setIsLoading] = useState(false);
-  const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+  const [message, setMessage] = useMessage();
 
   // Family editing form state
   const [familyData, setFamilyData] = useState({

--- a/frontend/src/features/tasks/components/TaskManagement.tsx
+++ b/frontend/src/features/tasks/components/TaskManagement.tsx
@@ -5,6 +5,7 @@ import { useFamily } from '../../../contexts/FamilyContext';
 import { taskApi } from '../../../services/api';
 import type { Task, CreateTaskData } from '../../../types';
 import { TaskOverrideCard, Modal, Button } from '../../../components/ui';
+import { useMessage } from '../../../hooks';
 import './TaskManagement.css';
 
 export const TaskManagement: React.FC = () => {
@@ -14,7 +15,7 @@ export const TaskManagement: React.FC = () => {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [editingTask, setEditingTask] = useState<Task | null>(null);
-  const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+  const [message, setMessage] = useMessage();
 
   // Modal state
   const [isAddTaskModalOpen, setIsAddTaskModalOpen] = useState(false);

--- a/frontend/src/features/templates/components/DayTemplateManagement.tsx
+++ b/frontend/src/features/templates/components/DayTemplateManagement.tsx
@@ -6,6 +6,7 @@ import type { Task, DayTemplate, DayTemplateItem, CreateDayTemplateData, FamilyM
 import { TaskOverrideCard } from '../../../components/ui/TaskOverrideCard';
 import { CustomSelect } from '../../../components/ui/CustomSelect';
 import Modal from '../../../components/ui/Modal';
+import { useMessage } from '../../../hooks';
 import './DayTemplateManagement.css';
 
 export const DayTemplateManagement: React.FC = () => {
@@ -14,7 +15,7 @@ export const DayTemplateManagement: React.FC = () => {
   
   const [tasks, setTasks] = useState<Task[]>([]);
   const [isLoading, setIsLoading] = useState(false);
-  const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+  const [message, setMessage] = useMessage();
 
   // DayTemplate state
   const [templates, setTemplates] = useState<DayTemplate[]>([]);

--- a/frontend/src/features/week/components/WeekScheduleView.tsx
+++ b/frontend/src/features/week/components/WeekScheduleView.tsx
@@ -3,6 +3,7 @@ import { useFamily } from '../../../contexts/FamilyContext';
 import { weekScheduleApi } from '../../../services/api';
 import type { ResolvedWeekSchedule, ResolvedTask } from '../../../types';
 import { ResolvedTaskCard } from '../../tasks/components/TaskAssignmentCard';
+import { useMessage } from '../../../hooks';
 import './WeekScheduleView.css';
 
 export const WeekScheduleView: React.FC = () => {
@@ -12,7 +13,7 @@ export const WeekScheduleView: React.FC = () => {
 
   const [currentWeekStart, setCurrentWeekStart] = useState<string>('');
   const [isLoading, setIsLoading] = useState(false);
-  const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+  const [message, setMessage] = useMessage();
 
   // Override modal state
   const [showOverrideModal, setShowOverrideModal] = useState(false);

--- a/frontend/src/features/week/components/WeekTemplateManagement.tsx
+++ b/frontend/src/features/week/components/WeekTemplateManagement.tsx
@@ -5,6 +5,7 @@ import { weekTemplateApi, dayTemplateApi } from '../../../services/api';
 import { CustomSelect } from '../../../components/ui/CustomSelect';
 import { TaskOverrideCard } from '../../../components/ui/TaskOverrideCard';
 import Modal from '../../../components/ui/Modal';
+import { useMessage } from '../../../hooks';
 import type { WeekTemplate, DayTemplate, DayTemplateItem, CreateWeekTemplateData, UpdateWeekTemplateData, ResolvedTask, Task } from '../../../types';
 import './WeekTemplateManagement.css';
 
@@ -18,7 +19,7 @@ export const WeekTemplateManagement: React.FC = () => {
   const [expandedTemplates, setExpandedTemplates] = useState<Record<string, boolean>>({});
   const [loadingItems, setLoadingItems] = useState<Record<string, boolean>>({});
   const [isLoading, setIsLoading] = useState(false);
-  const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+  const [message, setMessage] = useMessage();
 
   // Week template form state - convert to modal
   const [isAddRoutineModalOpen, setIsAddRoutineModalOpen] = useState(false);

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,0 +1,2 @@
+export { useCSRF, useRequiredCSRF, useCSRFOperations } from './useCSRF';
+export { useMessage } from './useMessage';

--- a/frontend/src/hooks/useMessage.ts
+++ b/frontend/src/hooks/useMessage.ts
@@ -1,0 +1,41 @@
+import { useState, useEffect, useCallback } from 'react';
+
+export interface Message {
+  type: 'success' | 'error';
+  text: string;
+}
+
+/**
+ * Custom hook for displaying messages with auto-dismiss functionality
+ * @param autoDismissDelay - Delay in milliseconds before auto-dismissing (default: 5000ms)
+ * @returns [message, setMessage] - Current message and setter function
+ */
+export function useMessage(autoDismissDelay: number = 5000): [Message | null, (message: Message | null) => void] {
+  const [message, setMessageState] = useState<Message | null>(null);
+
+  // Clear message after delay
+  useEffect(() => {
+    if (message) {
+      const timer = setTimeout(() => {
+        setMessageState(null);
+      }, autoDismissDelay);
+
+      // Cleanup timer if message changes or component unmounts
+      return () => clearTimeout(timer);
+    }
+    return undefined;
+  }, [message, autoDismissDelay]);
+
+  // Wrapper to ensure we always get a new object reference
+  // This ensures the effect runs even if setting the same message
+  const setMessage = useCallback((newMessage: Message | null) => {
+    if (newMessage) {
+      // Create a new object to trigger the effect
+      setMessageState({ ...newMessage });
+    } else {
+      setMessageState(null);
+    }
+  }, []);
+
+  return [message, setMessage];
+}


### PR DESCRIPTION
## Summary
- Added `useMessage` hook that automatically dismisses success/error messages after 5 seconds
- Updated all components using message state to use the new hook  
- Fixed TypeScript error to ensure all code paths return a value

## Test plan
- [ ] Create/edit a task and verify success message auto-dismisses after 5 seconds
- [ ] Update user profile and verify success message auto-dismisses
- [ ] Try an action that causes an error and verify error message auto-dismisses
- [ ] Create/edit family members and verify messages auto-dismiss
- [ ] Create/edit day templates and verify messages auto-dismiss
- [ ] Create/edit week templates and verify messages auto-dismiss
- [ ] Apply templates in weekly calendar and verify messages auto-dismiss

🤖 Generated with [Claude Code](https://claude.ai/code)