### PR TITLE
fix: Remove animation from weekly schedule component

### DIFF
--- a/frontend/src/components/calendar/WeeklyCalendar.css
+++ b/frontend/src/components/calendar/WeeklyCalendar.css
@@ -563,11 +563,7 @@
   animation: pulse 1.5s ease-in-out infinite;
 }
 
-/* Smooth transitions */
-.weekly-calendar-grid,
-.weekly-calendar-day {
-  transition: all 0.3s ease;
-}
+/* Smooth transitions removed for instant updates */
 
 /* Focus states for accessibility */
 .weekly-calendar-nav-btn:focus,


### PR DESCRIPTION
## Summary
- Removed the 0.3s CSS transition from weekly calendar grid and day elements
- Week navigation and initial page loads now happen instantly without any animation delay

## Changes
- Removed the CSS rule that was applying `transition: all 0.3s ease` to `.weekly-calendar-grid` and `.weekly-calendar-day`
- All other functional transitions (hover effects on buttons, etc.) are preserved

## Test plan
- [ ] Navigate between weeks using the arrow buttons - should be instant
- [ ] Load the home page - weekly schedule should appear immediately
- [ ] Verify hover effects on buttons still work properly
- [ ] Check that other animations (loading spinner) still work

🤖 Generated with [Claude Code](https://claude.ai/code)