### PR TITLE
fix: Restore time and duration modification in task reassignment

### DIFF
--- a/backend/src/services/week-schedule.service.ts
+++ b/backend/src/services/week-schedule.service.ts
@@ -497,6 +497,13 @@ export class WeekScheduleService {
             taskToReassign.memberId = override.newMemberId;
             taskToReassign.member = override.newMember || null;
             taskToReassign.source = 'override';
+            // Apply time and duration overrides if provided
+            if (override.overrideTime !== null) {
+              taskToReassign.overrideTime = override.overrideTime;
+            }
+            if (override.overrideDuration !== null) {
+              taskToReassign.overrideDuration = override.overrideDuration;
+            }
           }
           break;
         }

--- a/frontend/src/components/calendar/TaskOverrideModal.tsx
+++ b/frontend/src/components/calendar/TaskOverrideModal.tsx
@@ -109,8 +109,8 @@ export const TaskOverrideModal: React.FC<TaskOverrideModalProps> = ({
         action,
         originalMemberId: action === 'REASSIGN' ? (task?.memberId || null) : null,
         newMemberId: action === 'ADD' || action === 'REASSIGN' ? selectedMemberId : null,
-        overrideTime: action === 'ADD' ? overrideTime : null,
-        overrideDuration: action === 'ADD' ? overrideDuration : null,
+        overrideTime: action === 'ADD' || action === 'REASSIGN' ? overrideTime : null,
+        overrideDuration: action === 'ADD' || action === 'REASSIGN' ? overrideDuration : null,
       };
 
       try {
@@ -253,6 +253,34 @@ export const TaskOverrideModal: React.FC<TaskOverrideModalProps> = ({
               <p className="no-members-message">No other family members available for reassignment.</p>
             )}
           </div>
+          
+          {/* Show time and duration fields only for single task reassignment */}
+          {bulkTasks.length === 0 && task && (
+            <div className="form-row">
+              <div className="form-group">
+                <label>Start Time:</label>
+                <input
+                  type="time"
+                  value={overrideTime}
+                  onChange={(e) => setOverrideTime(e.target.value)}
+                  className="form-input"
+                  disabled={isSubmitting}
+                />
+              </div>
+              <div className="form-group">
+                <label>Duration (minutes):</label>
+                <input
+                  type="number"
+                  min="1"
+                  max="1440"
+                  value={overrideDuration}
+                  onChange={(e) => setOverrideDuration(parseInt(e.target.value) || 30)}
+                  className="form-input"
+                  disabled={isSubmitting}
+                />
+              </div>
+            </div>
+          )}
         </div>
       )}
     </>


### PR DESCRIPTION
## Summary
- Fixed the ability to modify time and duration when reassigning a single task
- Added missing UI fields and backend logic to properly handle these changes

## Problem
When reassigning a task, users could see time and duration fields but changes weren't being saved or displayed on task cards.

## Solution
1. **Frontend**: Added time and duration input fields to the REASSIGN action in `TaskOverrideModal`
2. **Backend**: Updated the REASSIGN case handler in `week-schedule.service.ts` to apply `overrideTime` and `overrideDuration` changes

## Test Plan
- [x] Open the weekly calendar
- [x] Click on a task to reassign it
- [x] Verify time and duration fields appear in the modal
- [x] Change the assigned member, time, and duration
- [x] Save the changes
- [x] Verify the task card displays the new time and duration
- [x] Verify bulk reassignment still works (without time/duration options)

## Screenshots
The reassign modal now includes time and duration fields for single task reassignment.

🤖 Generated with [Claude Code](https://claude.ai/code)