### PR TITLE
feat: Improve current day visual indicator

### DIFF
--- a/frontend/src/components/calendar/WeeklyCalendar.css
+++ b/frontend/src/components/calendar/WeeklyCalendar.css
@@ -120,8 +120,19 @@
 }
 
 .weekly-calendar-day.is-today {
-  background-color: #f0f9ff;
-  border-top: 3px solid #3b82f6;
+  background: linear-gradient(to bottom, #f0f9ff 0%, #ffffff 100%);
+  position: relative;
+  box-shadow: inset 0 0 0 1px rgba(59, 130, 246, 0.1);
+}
+
+.weekly-calendar-day.is-today::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, rgba(59, 130, 246, 0.3) 0%, rgba(59, 130, 246, 0.8) 50%, rgba(59, 130, 246, 0.3) 100%);
 }
 
 /* Day Header */
@@ -166,8 +177,9 @@
 }
 
 .weekly-calendar-day.is-today .weekly-calendar-day-header {
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.12) 0%, rgba(96, 165, 250, 0.12) 100%);
-  border-color: rgba(59, 130, 246, 0.3);
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.08) 0%, rgba(96, 165, 250, 0.08) 100%);
+  border-color: rgba(59, 130, 246, 0.2);
+  box-shadow: 0 2px 6px rgba(59, 130, 246, 0.12);
 }
 
 .weekly-calendar-day.is-today .weekly-calendar-day-header::before {
@@ -176,6 +188,7 @@
 
 .weekly-calendar-day-info {
   flex: 1;
+  position: relative;
 }
 
 .weekly-calendar-day-name {
@@ -187,8 +200,10 @@
 }
 
 .weekly-calendar-day.is-today .weekly-calendar-day-name {
-  color: #1d4ed8;
+  color: #2563eb;
+  font-weight: 800;
 }
+
 
 .weekly-calendar-day-controls {
   display: flex;
@@ -243,14 +258,14 @@
 }
 
 .weekly-calendar-day.is-today .weekly-calendar-day-override-btn {
-  background-color: rgba(255, 255, 255, 0.9);
-  border-color: rgba(59, 130, 246, 0.3);
-  color: #3b82f6;
+  background-color: rgba(255, 255, 255, 0.8);
+  border-color: rgba(99, 102, 241, 0.25);
+  color: #4f46e5;
 }
 
 .weekly-calendar-day.is-today .weekly-calendar-day-override-btn:hover:not(:disabled) {
-  background-color: rgba(59, 130, 246, 0.1);
-  border-color: rgba(59, 130, 246, 0.4);
+  background-color: rgba(99, 102, 241, 0.1);
+  border-color: rgba(99, 102, 241, 0.35);
 }
 
 /* Tasks Lane */

--- a/frontend/src/components/calendar/WeeklyCalendar.tsx
+++ b/frontend/src/components/calendar/WeeklyCalendar.tsx
@@ -531,8 +531,6 @@ export const WeeklyCalendar: React.FC<WeeklyCalendarProps> = ({ className }) => 
 
   const formatDate = (dateString: string): string => {
     const date = new Date(dateString + 'T00:00:00.000Z');
-    const today = new Date();
-    const isToday = date.toDateString() === today.toDateString();
     
     const dayName = date.toLocaleDateString('en-US', { weekday: 'long' });
     const dayNumber = date.getDate();

--- a/frontend/src/components/calendar/WeeklyCalendar.tsx
+++ b/frontend/src/components/calendar/WeeklyCalendar.tsx
@@ -537,7 +537,7 @@ export const WeeklyCalendar: React.FC<WeeklyCalendarProps> = ({ className }) => 
     const dayName = date.toLocaleDateString('en-US', { weekday: 'long' });
     const dayNumber = date.getDate();
     
-    return isToday ? `${dayName} ${dayNumber} (Today)` : `${dayName} ${dayNumber}`;
+    return `${dayName} ${dayNumber}`;
   };
 
   const formatWeekRange = (weekStartDate: string): string => {


### PR DESCRIPTION
## Summary
This PR refines the visual indicator for the current day to be more elegant and avoid layout shifts.

### Changes Made:
- **No more layout shifts**: Replaced 3px top border with overlay gradient line using ::after
- **Subtle gradient background**: Changed from solid blue to a gentle gradient (#f0f9ff to white)
- **Soft inner border**: Using box-shadow for a non-intrusive border effect
- **Gradient top indicator**: 3px fading blue line that doesn't affect layout
- **Refined header styling**: More subtle blue gradient that matches other headers
- **Bold blue day name**: Clear text indication without being overwhelming
- **Removed redundant text**: No more "(Today)" suffix in day names
- **Consistent heights**: All day headers maintain the same height

## Visual Impact
- Current day is clearly indicated without being too prominent
- No layout shifts or misalignments between days
- Professional, modern appearance
- Better visual harmony with the overall design

## Test Plan
- [x] Verify no layout shift when current day changes
- [x] Check gradient line appears at top of current day
- [x] Ensure all headers have consistent height
- [x] Verify current day styling is visible but not overwhelming
- [x] Test responsive behavior on mobile/tablet
- [x] Confirm no visual glitches or overlaps

🤖 Generated with [Claude Code](https://claude.ai/code)