### PR TITLE
feat: Move TaskSplitIndicator to WeeklyCalendar header

### DIFF
--- a/frontend/src/components/calendar/WeeklyCalendar.tsx
+++ b/frontend/src/components/calendar/WeeklyCalendar.tsx
@@ -8,6 +8,7 @@ import { TaskOverrideCard, Button, UserAvatar, DropdownMenu } from '../ui';
 import type { DropdownMenuItem } from '../ui';
 import RoutinesIcon from '../ui/icons/RoutinesIcon';
 import { TaskOverrideModal } from './TaskOverrideModal';
+import { TaskSplitIndicator } from '../layout/TaskSplitIndicator';
 import { useMessage } from '../../hooks';
 import type { ResolvedWeekSchedule, ResolvedTask, WeekTemplate, DayTemplate, DayTemplateItem, Task, User, CreateTaskOverrideData } from '../../types';
 import './WeeklyCalendar.css';
@@ -648,6 +649,8 @@ export const WeeklyCalendar: React.FC<WeeklyCalendarProps> = ({ className }) => 
             </span>
           )}
         </div>
+        
+        <TaskSplitIndicator />
         
         <div className="weekly-calendar-controls">
           <button

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -6,7 +6,6 @@ import { UserProfile } from '../../features/auth/components/UserProfile';
 import Navigation from './Navigation';
 import Logo from './Logo';
 import { ShiftIndicator } from './ShiftIndicator';
-import { TaskSplitIndicator } from './TaskSplitIndicator';
 import './Layout.css';
 
 const Layout: React.FC = () => {
@@ -24,7 +23,6 @@ const Layout: React.FC = () => {
           <div className="layout-header-left">
             <Logo />
             <ShiftIndicator />
-            <TaskSplitIndicator />
           </div>
           
           <div className="layout-header-center">

--- a/frontend/src/components/layout/TaskSplitIndicator.css
+++ b/frontend/src/components/layout/TaskSplitIndicator.css
@@ -4,6 +4,12 @@
   margin-left: 1.5rem;
 }
 
+/* When inside WeeklyCalendar header */
+.weekly-calendar-header .task-split-indicator {
+  margin-left: auto;
+  margin-right: 1rem;
+}
+
 .task-split-indicator-button {
   display: flex;
   align-items: center;
@@ -21,10 +27,29 @@
   transform: translateY(-1px);
 }
 
+/* When inside WeeklyCalendar header */
+.weekly-calendar-header .task-split-indicator-button {
+  background: rgba(255, 255, 255, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  backdrop-filter: blur(10px);
+  padding: 6px 12px;
+  border-radius: 6px;
+}
+
+.weekly-calendar-header .task-split-indicator-button:hover {
+  background: rgba(255, 255, 255, 0.3);
+  border-color: rgba(255, 255, 255, 0.5);
+}
+
 .task-split-indicator-content {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+}
+
+/* When inside WeeklyCalendar header */
+.weekly-calendar-header .task-split-indicator-content {
+  gap: 0.75rem;
 }
 
 .task-split-indicator-score {
@@ -35,6 +60,20 @@
 .task-split-indicator-label {
   font-size: 0.875rem;
   color: #6b7280;
+  font-weight: 500;
+}
+
+/* When inside WeeklyCalendar header */
+.weekly-calendar-header .task-split-indicator-score {
+  color: white !important;
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-shadow: 0 0 8px rgba(255, 255, 255, 0.5);
+}
+
+.weekly-calendar-header .task-split-indicator-label {
+  color: rgba(255, 255, 255, 0.95);
+  font-size: 0.75rem;
   font-weight: 500;
 }
 
@@ -202,6 +241,25 @@
   font-weight: 600;
 }
 
+/* Tablet responsiveness */
+@media (max-width: 1024px) {
+  .weekly-calendar-header .task-split-indicator {
+    margin-right: 0.5rem;
+  }
+  
+  .weekly-calendar-header .task-split-indicator-button {
+    padding: 6px 10px;
+  }
+  
+  .weekly-calendar-header .task-split-indicator-score {
+    font-size: 0.8125rem;
+  }
+  
+  .weekly-calendar-header .task-split-indicator-label {
+    font-size: 0.6875rem;
+  }
+}
+
 /* Mobile responsiveness */
 @media (max-width: 768px) {
   .task-split-indicator-button {
@@ -214,6 +272,11 @@
 
   .task-split-indicator-label {
     font-size: 0.75rem;
+  }
+
+  /* Hide on mobile when in WeeklyCalendar header to save space */
+  .weekly-calendar-header .task-split-indicator {
+    display: none;
   }
 
   .task-split-dropdown {


### PR DESCRIPTION
## Summary
- Moved TaskSplitIndicator from the global application header to the WeeklyCalendar component
- Updated styling to match the WeeklyCalendar header design
- Now shows task distribution metrics only on the Home page where they're most relevant

## Changes

### Component Relocation
- **Removed from Layout.tsx**: Removed TaskSplitIndicator from the global app header
- **Added to WeeklyCalendar.tsx**: Integrated TaskSplitIndicator into the WeeklyCalendar header
- Positioned between the title section and navigation controls with auto margin

### Styling Updates
- **Height alignment**: Adjusted padding to `6px 12px` to match header buttons
- **Glassmorphism effect**: Applied transparent white background with backdrop blur
- **Text visibility**: 
  - Score uses white text with subtle glow effect
  - Label uses slightly transparent white
  - Removed color coding in favor of consistent white text on purple gradient
- **Font sizes**: Reduced to match header button proportions
- **Responsive design**:
  - Tablet: Smaller padding and font sizes
  - Mobile: Hidden to preserve space

## Visual Impact
The TaskSplitIndicator now:
- Appears only on the Home page within WeeklyCalendar
- Matches the visual height and style of other header elements
- Provides better contrast on the purple gradient background
- Maintains responsive behavior across device sizes

## Test plan
- [x] Verify TaskSplitIndicator no longer appears in global header
- [x] Confirm it displays correctly in WeeklyCalendar header
- [x] Check styling matches other header buttons
- [x] Test responsive behavior on different screen sizes
- [x] Ensure dropdown functionality still works
- [x] Verify linting passes

🤖 Generated with [Claude Code](https://claude.ai/code)