### PR TITLE
feat: Redesign mobile WeeklyCalendar header to match frontend

### DIFF
--- a/mobile/src/components/ui/ShiftIndicator.tsx
+++ b/mobile/src/components/ui/ShiftIndicator.tsx
@@ -364,7 +364,7 @@ const styles = StyleSheet.create({
   },
   singleLineText: {
     fontSize: 14,
-    color: '#6b7280',
+    color: 'rgba(255, 255, 255, 0.9)',
     fontWeight: '500',
   },
   statusText: {
@@ -374,14 +374,14 @@ const styles = StyleSheet.create({
     letterSpacing: 0.5,
   },
   currentShift: {
-    color: '#059669', // Green for current shift
+    color: '#86efac', // Light green for current shift
   },
   nextShift: {
-    color: '#0369a1', // Blue for next shift
+    color: '#93c5fd', // Light blue for next shift
   },
   timeText: {
     fontSize: 14,
-    color: '#6b7280',
+    color: 'rgba(255, 255, 255, 0.9)',
     fontWeight: '500',
   },
 }); 

--- a/mobile/src/components/ui/TaskSplitIndicator.tsx
+++ b/mobile/src/components/ui/TaskSplitIndicator.tsx
@@ -1,0 +1,297 @@
+import React, { useEffect, useState, useRef } from 'react';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  Modal,
+  ScrollView,
+  Dimensions,
+} from 'react-native';
+import { useFamily } from '../../contexts/FamilyContext';
+import { analyticsApi } from '../../services/api';
+import type { TaskSplitAnalytics } from '../../types';
+import { UserAvatar } from './UserAvatar';
+
+const { width: screenWidth } = Dimensions.get('window');
+
+interface TaskSplitIndicatorProps {
+  currentWeekStart: string;
+}
+
+export const TaskSplitIndicator: React.FC<TaskSplitIndicatorProps> = ({ currentWeekStart }) => {
+  const { currentFamily } = useFamily();
+  const [analytics, setAnalytics] = useState<TaskSplitAnalytics | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  useEffect(() => {
+    if (currentFamily && currentWeekStart) {
+      loadAnalytics();
+    }
+  }, [currentFamily, currentWeekStart]);
+
+  const loadAnalytics = async () => {
+    if (!currentFamily || !currentWeekStart) return;
+
+    try {
+      setIsLoading(true);
+      const response = await analyticsApi.getTaskSplit(currentFamily.id, currentWeekStart);
+      setAnalytics(response.data.data);
+    } catch (error) {
+      // Failed to load analytics - component will not render
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (!currentFamily || isLoading || !analytics) {
+    return null;
+  }
+
+  // Filter out virtual members for display
+  const realMembers = analytics.memberStats.filter(member => !member.isVirtual);
+  
+  // Check if there are no tasks
+  const hasNoTasks = analytics.totalMinutes === 0;
+  
+  // Get fairness indicator color
+  const getFairnessColor = (score: number) => {
+    if (score >= 90) return '#10b981'; // green
+    if (score >= 70) return '#f59e0b'; // amber
+    return '#ef4444'; // red
+  };
+
+  const getFairnessLabel = (score: number) => {
+    if (score >= 90) return 'Fair';
+    if (score >= 70) return 'OK';
+    return 'Unfair';
+  };
+
+  return (
+    <>
+      <TouchableOpacity
+        style={styles.indicatorButton}
+        onPress={() => setIsExpanded(true)}
+      >
+        <Text style={styles.score}>
+          {analytics.fairnessScore}%
+        </Text>
+        <Text style={styles.label}>
+          {getFairnessLabel(analytics.fairnessScore)}
+        </Text>
+      </TouchableOpacity>
+
+      <Modal
+        visible={isExpanded}
+        animationType="slide"
+        transparent={true}
+        onRequestClose={() => setIsExpanded(false)}
+      >
+        <View style={styles.modalOverlay}>
+          <View style={styles.modalContent}>
+            <View style={styles.modalHeader}>
+              <Text style={styles.modalTitle}>Task Distribution (4 weeks)</Text>
+              <TouchableOpacity
+                style={styles.closeButton}
+                onPress={() => setIsExpanded(false)}
+              >
+                <Text style={styles.closeButtonText}>✕</Text>
+              </TouchableOpacity>
+            </View>
+
+            <ScrollView style={styles.membersContainer}>
+              {hasNoTasks ? (
+                <View style={styles.noTasks}>
+                  <Text style={styles.noTasksText}>No tasks assigned in the last 4 weeks</Text>
+                  <Text style={styles.noTasksHint}>Start assigning tasks to see distribution</Text>
+                </View>
+              ) : realMembers.length === 0 ? (
+                <View style={styles.noTasks}>
+                  <Text style={styles.noTasksText}>No family members found</Text>
+                </View>
+              ) : (
+                realMembers.map(member => (
+                  <View key={member.memberId} style={styles.memberRow}>
+                    <View style={styles.memberInfo}>
+                      <UserAvatar
+                        firstName={member.firstName}
+                        lastName={member.lastName}
+                        avatarUrl={member.avatarUrl ?? null}
+                        size={32}
+                      />
+                      <Text style={styles.memberName}>{member.memberName}</Text>
+                    </View>
+                    <View style={styles.memberStats}>
+                      <View style={styles.barContainer}>
+                        <View 
+                          style={[
+                            styles.barFill,
+                            { width: `${member.percentage}%` }
+                          ]}
+                        />
+                      </View>
+                      <Text style={styles.percentage}>
+                        {Math.round(member.percentage)}%
+                      </Text>
+                    </View>
+                    <Text style={styles.time}>
+                      {Math.floor(member.totalMinutes / 60)}h {member.totalMinutes % 60}m
+                    </Text>
+                  </View>
+                ))
+              )}
+            </ScrollView>
+
+            <View style={styles.summary}>
+              <View style={styles.summaryRow}>
+                <Text style={styles.summaryLabel}>Total time:</Text>
+                <Text style={styles.summaryValue}>
+                  {Math.floor(analytics.totalMinutes / 60)}h {analytics.totalMinutes % 60}m
+                </Text>
+              </View>
+              <View style={styles.summaryRow}>
+                <Text style={styles.summaryLabel}>Average per person:</Text>
+                <Text style={styles.summaryValue}>
+                  {Math.floor(analytics.averageMinutesPerMember / 60)}h {analytics.averageMinutesPerMember % 60}m
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </Modal>
+    </>
+  );
+};
+
+const styles = StyleSheet.create({
+  indicatorButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: 'rgba(255, 255, 255, 0.2)',
+    borderRadius: 6,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    gap: 8,
+  },
+  score: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#ffffff',
+  },
+  label: {
+    fontSize: 12,
+    color: 'rgba(255, 255, 255, 0.9)',
+    fontWeight: '500',
+  },
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    justifyContent: 'flex-end',
+  },
+  modalContent: {
+    backgroundColor: '#ffffff',
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    maxHeight: '80%',
+  },
+  modalHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: '#e5e7eb',
+  },
+  modalTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#111827',
+  },
+  closeButton: {
+    padding: 8,
+  },
+  closeButtonText: {
+    fontSize: 20,
+    color: '#6b7280',
+  },
+  membersContainer: {
+    padding: 16,
+  },
+  noTasks: {
+    alignItems: 'center',
+    paddingVertical: 32,
+  },
+  noTasksText: {
+    fontSize: 16,
+    color: '#6b7280',
+    marginBottom: 8,
+  },
+  noTasksHint: {
+    fontSize: 14,
+    color: '#9ca3af',
+    fontStyle: 'italic',
+  },
+  memberRow: {
+    marginBottom: 16,
+  },
+  memberInfo: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    marginBottom: 8,
+  },
+  memberName: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: '#374151',
+  },
+  memberStats: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginBottom: 4,
+  },
+  barContainer: {
+    flex: 1,
+    height: 8,
+    backgroundColor: '#e5e7eb',
+    borderRadius: 4,
+    overflow: 'hidden',
+  },
+  barFill: {
+    height: '100%',
+    backgroundColor: '#6366f1',
+  },
+  percentage: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#374151',
+    minWidth: 40,
+    textAlign: 'right',
+  },
+  time: {
+    fontSize: 12,
+    color: '#6b7280',
+  },
+  summary: {
+    backgroundColor: '#f9fafb',
+    padding: 16,
+    borderTopWidth: 1,
+    borderTopColor: '#e5e7eb',
+  },
+  summaryRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 8,
+  },
+  summaryLabel: {
+    fontSize: 14,
+    color: '#6b7280',
+  },
+  summaryValue: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#111827',
+  },
+});

--- a/mobile/src/components/ui/index.ts
+++ b/mobile/src/components/ui/index.ts
@@ -4,6 +4,7 @@ export { LoadingSpinner } from './LoadingSpinner';
 export { TaskOverrideCard } from './TaskOverrideCard';
 export { UserAvatar } from './UserAvatar';
 export { ShiftIndicator } from './ShiftIndicator';
+export { TaskSplitIndicator } from './TaskSplitIndicator';
 export { UserMenu } from './UserMenu';
 export { UserProfile } from './UserProfile';
 export { default as Logo } from './Logo'; 

--- a/mobile/src/screens/HomeScreen.tsx
+++ b/mobile/src/screens/HomeScreen.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {
   StyleSheet,
-  SafeAreaView,
+  View,
 } from 'react-native';
 import { useAuth } from '../contexts/AuthContext';
 import { useFamily } from '../contexts/FamilyContext';
@@ -12,10 +12,10 @@ export const HomeScreen: React.FC = () => {
   const { currentFamily } = useFamily();
 
   return (
-    <SafeAreaView style={styles.container}>
+    <View style={styles.container}>
       {/* Weekly Calendar */}
       <WeeklyCalendar style={styles.calendar} />
-    </SafeAreaView>
+    </View>
   );
 };
 


### PR DESCRIPTION
## Summary
- Redesigned mobile WeeklyCalendar header to match the recent frontend updates
- Added purple gradient background and improved visual consistency
- Simplified navigation by removing redundant controls

## Changes
- **Added purple gradient header** - Using expo-linear-gradient with colors `#667eea` to `#764ba2`
- **Removed week navigation** - Eliminated arrow buttons and "Today" button from header
- **Removed week date display** - Cleaned up header by removing date range text
- **Removed day navigation** - Eliminated the inner navigation with arrows and day indicators
- **Added TaskSplitIndicator** - Ported the task distribution indicator component to mobile
- **Updated ShiftIndicator colors** - Changed to light colors for visibility on gradient background
- **Added admin controls** - Apply Routine and Revert buttons for admin users
- **Fixed safe area handling** - Extended gradient to cover iPhone notch/island area
- **Updated HomeScreen** - Changed from SafeAreaView to View to allow gradient extension

## Visual Changes
The mobile app now matches the frontend's modern purple gradient header design, providing a consistent experience across platforms. The simplified navigation reduces clutter while maintaining all essential functionality.

## Test plan
- [x] Test on iPhone with notch/island to ensure gradient extends properly
- [x] Verify ShiftIndicator is visible on gradient background
- [x] Test TaskSplitIndicator modal functionality
- [x] Verify admin controls appear only for admin users
- [ ] Test on various screen sizes

🤖 Generated with [Claude Code](https://claude.ai/code)