### PR TITLE
feat: Add task action dialog to mobile calendar

### DIFF
--- a/mobile/src/components/calendar/WeeklyCalendar.tsx
+++ b/mobile/src/components/calendar/WeeklyCalendar.tsx
@@ -6,6 +6,7 @@ import {
   ScrollView,
   TouchableOpacity,
   Dimensions,
+  Alert,
 } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -477,16 +478,34 @@ export const WeeklyCalendar: React.FC<WeeklyCalendarProps> = ({ style }) => {
                         hideAvatar={isMultiTaskShift}
                         onPress={(task) => {
                           if (isAdmin) {
-                            console.log('WeeklyCalendar - Opening reassign modal:', {
-                              task,
-                              familyMembersCount: familyMembers.length,
-                              familyMembers
-                            });
-                            setTaskOverrideAction('REASSIGN');
-                            setSelectedTask(task);
-                            setSelectedTasks([]); // Clear bulk selection
-                            setTaskOverrideDate(day.date);
-                            setShowTaskOverrideModal(true);
+                            Alert.alert(
+                              'Task Actions',
+                              `What would you like to do with "${task.task.name}"?`,
+                              [
+                                { 
+                                  text: 'Reassign', 
+                                  onPress: () => {
+                                    setTaskOverrideAction('REASSIGN');
+                                    setSelectedTask(task);
+                                    setSelectedTasks([]);
+                                    setTaskOverrideDate(day.date);
+                                    setShowTaskOverrideModal(true);
+                                  }
+                                },
+                                { 
+                                  text: 'Remove', 
+                                  onPress: () => {
+                                    setTaskOverrideAction('REMOVE');
+                                    setSelectedTask(task);
+                                    setSelectedTasks([]);
+                                    setTaskOverrideDate(day.date);
+                                    setShowTaskOverrideModal(true);
+                                  },
+                                  style: 'destructive' 
+                                },
+                                { text: 'Cancel', style: 'cancel' }
+                              ]
+                            );
                           }
                         }}
                       />


### PR DESCRIPTION
## Summary

- Added a system dialog when tapping tasks in the mobile calendar view
- Users now see options to Reassign, Remove, or Cancel before the task override modal opens
- Consistent with the existing pattern in the Tasks page

## Changes

1. **Updated WeeklyCalendar component** to use `Alert.alert()` when a task is pressed
2. Shows native system dialog with three options:
   - **Reassign** - Opens TaskOverrideModal with REASSIGN action
   - **Remove** - Opens TaskOverrideModal with REMOVE action (destructive style)
   - **Cancel** - Dismisses the alert

## Test Plan

- [ ] Launch the mobile app
- [ ] Navigate to the home screen (calendar view)
- [ ] Tap on any task
- [ ] Verify that a system alert appears with "Task Actions" title
- [ ] Verify the alert shows the task name in the message
- [ ] Test each option:
  - [ ] Reassign - opens the reassign modal
  - [ ] Remove - opens the remove modal
  - [ ] Cancel - dismisses the alert
- [ ] Verify the interaction matches the Tasks page behavior

🤖 Generated with [Claude Code](https://claude.ai/code)