### PR TITLE
fix: add notifications and real-time updates for week routine changes

### DIFF
--- a/backend/src/__tests__/unit/week-schedule.service.test.ts
+++ b/backend/src/__tests__/unit/week-schedule.service.test.ts
@@ -595,9 +595,24 @@ describe('WeekScheduleService', () => {
       const familyId = 'family-1';
       const weekStartDate = '2024-01-01';
 
+      // Mock the findMany call for task overrides
+      (mockPrisma.taskOverride.findMany as jest.Mock).mockResolvedValue([]);
       (mockPrisma.weekOverride.deleteMany as jest.Mock).mockResolvedValue({ count: 1 });
 
       await weekScheduleService.removeWeekOverride(familyId, weekStartDate);
+
+      expect(mockPrisma.taskOverride.findMany).toHaveBeenCalledWith({
+        where: {
+          weekOverride: {
+            familyId,
+            weekStartDate: new Date('2024-01-01T00:00:00.000Z'),
+          },
+        },
+        include: {
+          task: true,
+          weekOverride: true,
+        },
+      });
 
       expect(mockPrisma.weekOverride.deleteMany).toHaveBeenCalledWith({
         where: {

--- a/backend/src/routes/week-schedule.routes.ts
+++ b/backend/src/routes/week-schedule.routes.ts
@@ -210,7 +210,7 @@ router.delete('/:familyId/week-schedule/override', async (req: AuthenticatedRequ
     const userId = req.user!.userId;
     await checkFamilyAdmin(userId, familyId);
 
-    await weekScheduleService.removeWeekOverride(familyId, weekStartDate);
+    await weekScheduleService.removeWeekOverride(familyId, weekStartDate, userId);
 
     return res.status(200).json({ 
       message: 'Week override removed successfully',

--- a/backend/src/services/websocket.service.ts
+++ b/backend/src/services/websocket.service.ts
@@ -55,6 +55,9 @@ export class WebSocketService {
       },
       transports: ['websocket', 'polling'],
       allowEIO3: true, // Allow different Socket.IO versions
+      pingInterval: 25000, // Send ping every 25 seconds
+      pingTimeout: 60000, // Wait 60 seconds for pong
+      connectTimeout: 45000, // 45 seconds to establish connection
     });
 
     this.setupSocketHandlers();
@@ -201,8 +204,11 @@ export class WebSocketService {
    */
   public sendToFamily(familyId: string, event: string, data: any) {
     const roomName = `family:${familyId}`;
+    const room = this.io.sockets.adapter.rooms.get(roomName);
+    const clientCount = room ? room.size : 0;
+    console.log(`📤 Sending ${event} to family room ${roomName} (${clientCount} clients)`);
+    console.log(`📤 Event data:`, JSON.stringify(data, null, 2));
     this.io.to(roomName).emit(event, data);
-    console.log(`Sent ${event} to family room ${roomName}`);
   }
 
   /**

--- a/backend/src/services/week-schedule.service.ts
+++ b/backend/src/services/week-schedule.service.ts
@@ -292,6 +292,30 @@ export class WeekScheduleService {
       await this.sendTaskReassignmentNotifications(familyId, finalOverrides, adminUserId);
     }
 
+    // Emit general WebSocket event for schedule update
+    const webSocketService = getWebSocketService();
+    if (webSocketService) {
+      console.log('📅 Emitting week-schedule-updated event for family:', familyId);
+      console.log('📅 Event data:', {
+        type: 'week-schedule-updated',
+        familyId,
+        weekStartDate: data.weekStartDate,
+        isTemplateChange: !!data.weekTemplateId,
+        hasOverrides: finalOverrides.length > 0,
+      });
+      webSocketService.sendToFamily(familyId, 'week-schedule-updated', {
+        type: 'week-schedule-updated',
+        familyId,
+        weekStartDate: data.weekStartDate,
+        date: data.weekStartDate, // Add date field for consistency
+        message: `Week schedule has been updated`,
+        isTemplateChange: !!data.weekTemplateId,
+        hasOverrides: finalOverrides.length > 0,
+      });
+    } else {
+      console.error('❌ WebSocket service not available for week-schedule-updated event!');
+    }
+
     // Return the updated week override with relations
     return await this.getWeekOverrideById(weekOverride.id, familyId);
   }

--- a/mobile/src/components/calendar/WeeklyCalendar.tsx
+++ b/mobile/src/components/calendar/WeeklyCalendar.tsx
@@ -166,12 +166,14 @@ export const WeeklyCalendar: React.FC<WeeklyCalendarProps> = ({ style }) => {
     on('task-assigned', handleTaskUpdate);
     on('task-unassigned', handleTaskUpdate);
     on('task-schedule-updated', handleTaskUpdate);
+    on('week-schedule-reverted', handleTaskUpdate);
     
     // Cleanup listeners on unmount
     return () => {
       off('task-assigned', handleTaskUpdate);
       off('task-unassigned', handleTaskUpdate);
       off('task-schedule-updated', handleTaskUpdate);
+      off('week-schedule-reverted', handleTaskUpdate);
     };
   }, [currentFamily, currentWeekStart, on, off, loadWeekSchedule]);
   

--- a/mobile/src/contexts/NotificationContext.tsx
+++ b/mobile/src/contexts/NotificationContext.tsx
@@ -286,6 +286,22 @@ export const NotificationProvider: React.FC<NotificationProviderProps> = ({ chil
       eventListeners.current['task-schedule-updated']?.forEach(callback => callback(data));
     });
 
+    // Week schedule reverted event
+    newSocket.on('week-schedule-reverted', (data) => {
+      console.log('📅 Week schedule reverted event received:', data);
+      addNotification({
+        type: 'week-schedule-reverted',
+        title: 'Schedule Reverted',
+        message: data.message,
+        data: {
+          ...data,
+          screen: 'Home', // Navigate to home/calendar when tapped
+        },
+      });
+      // Forward the event to any registered listeners
+      eventListeners.current['week-schedule-reverted']?.forEach(callback => callback(data));
+    });
+
     socketRef.current = newSocket;
   }, [addNotification]);
 

--- a/mobile/src/contexts/NotificationContext.tsx
+++ b/mobile/src/contexts/NotificationContext.tsx
@@ -105,6 +105,13 @@ export const NotificationProvider: React.FC<NotificationProviderProps> = ({ chil
   // Connect to WebSocket
   const connect = useCallback(async () => {
     console.log('🚀 Connect function called');
+    
+    // Check if already connecting or connected
+    if (socketRef.current?.connected) {
+      console.log('✅ Socket already connected, skipping connection');
+      return;
+    }
+    
     const token = await AsyncStorage.getItem('authToken');
     console.log('🔑 Retrieved token:', token ? 'Token exists' : 'No token');
     console.log('📊 Current state:', {
@@ -112,10 +119,8 @@ export const NotificationProvider: React.FC<NotificationProviderProps> = ({ chil
       isAlreadyConnected: socketRef.current?.connected
     });
     
-    if (!token || socketRef.current?.connected) {
-      console.log('⏹️ Connect aborted:', {
-        reason: !token ? 'No token' : 'Already connected'
-      });
+    if (!token) {
+      console.log('⏹️ Connect aborted: No token');
       return;
     }
 
@@ -135,8 +140,14 @@ export const NotificationProvider: React.FC<NotificationProviderProps> = ({ chil
       timeout: 20000,
       forceNew: true,
       reconnection: true,
-      reconnectionAttempts: 5,
+      reconnectionAttempts: Infinity, // Keep trying to reconnect
       reconnectionDelay: 1000,
+      reconnectionDelayMax: 5000,
+      randomizationFactor: 0.5,
+      autoConnect: true,
+      // Add ping/pong to keep connection alive
+      pingInterval: 25000,
+      pingTimeout: 60000,
     });
 
     // Connection event handlers
@@ -302,6 +313,29 @@ export const NotificationProvider: React.FC<NotificationProviderProps> = ({ chil
       eventListeners.current['week-schedule-reverted']?.forEach(callback => callback(data));
     });
 
+    // Week schedule updated event (when applying routines)
+    newSocket.on('week-schedule-updated', (data) => {
+      console.log('📅 Week schedule updated event received:', data);
+      console.log('📅 Event data details:', JSON.stringify(data, null, 2));
+      console.log('📅 Registered listeners for week-schedule-updated:', eventListeners.current['week-schedule-updated']?.length || 0);
+      
+      addNotification({
+        type: 'week-schedule-updated',
+        title: 'Schedule Updated',
+        message: data.message,
+        data: {
+          ...data,
+          screen: 'Home', // Navigate to home/calendar when tapped
+        },
+      });
+      
+      // Forward the event to any registered listeners
+      eventListeners.current['week-schedule-updated']?.forEach((callback, index) => {
+        console.log(`📅 Calling listener ${index + 1} for week-schedule-updated`);
+        callback(data);
+      });
+    });
+
     socketRef.current = newSocket;
   }, [addNotification]);
 
@@ -376,20 +410,27 @@ export const NotificationProvider: React.FC<NotificationProviderProps> = ({ chil
     return () => {
       disconnect();
     };
-  }, [isAuthenticated, connect, disconnect]);
+  }, [isAuthenticated]); // Remove connect and disconnect from dependencies to prevent loops
 
   // Handle app state changes for background notifications
   useEffect(() => {
     const handleAppStateChange = (nextAppState: string) => {
+      console.log('📱 App state changed to:', nextAppState);
       if (nextAppState === 'active') {
         // App came to foreground - clear any pending notifications
         NotificationService.clearDeliveredNotifications();
+        
+        // Reconnect WebSocket if disconnected
+        if (isAuthenticated && !socketRef.current?.connected) {
+          console.log('📱 App active - reconnecting WebSocket...');
+          connect();
+        }
       }
     };
 
     const subscription = AppState.addEventListener('change', handleAppStateChange);
     return () => subscription?.remove();
-  }, []);
+  }, [isAuthenticated, connect]);
 
   // Initialize notification service
   useEffect(() => {
@@ -399,9 +440,14 @@ export const NotificationProvider: React.FC<NotificationProviderProps> = ({ chil
   // Cleanup on unmount
   useEffect(() => {
     return () => {
-      disconnect();
+      // Only disconnect when component is truly unmounting
+      if (socketRef.current) {
+        console.log('🔌 Component unmounting - disconnecting WebSocket');
+        socketRef.current.disconnect();
+        socketRef.current = null;
+      }
     };
-  }, [disconnect]);
+  }, []); // Empty deps - only run on mount/unmount
 
   const value: NotificationContextType = {
     notifications,

--- a/mobile/src/services/NotificationService.ts
+++ b/mobile/src/services/NotificationService.ts
@@ -385,6 +385,11 @@ export class NotificationService {
           icon: '📅',
           title: 'Schedule Updated',
         };
+      case 'week-schedule-reverted':
+        return {
+          icon: '↩️',
+          title: 'Schedule Reverted',
+        };
       default:
         return {
           icon: '🔔',


### PR DESCRIPTION
## Summary
This PR fixes the issue where applying or reverting weekly routines doesn't trigger notifications or real-time updates on the mobile app.

## Problem
- When reverting a weekly routine, users who had tasks assigned weren't notified
- When applying a routine with `replaceExisting=true`, users losing tasks weren't notified
- Mobile app didn't update in real-time when routines were changed

## Solution

### Backend Changes
1. **Enhanced `removeWeekOverride`**:
   - Tracks all task assignments that will be removed
   - Sends notifications to affected users
   - Emits `week-schedule-reverted` WebSocket event

2. **Enhanced `applyWeekOverride`**:
   - When `replaceExisting=true`, tracks removed assignments
   - Sends notifications for both removed and new assignments
   - Ensures all affected users are notified

3. **New notification flow**:
   - `sendTaskRemovalNotifications` method handles bulk task removals
   - Notifications include task name, date, and admin who made the change

### Mobile App Changes
1. **Added event listeners**:
   - `week-schedule-reverted` event in NotificationContext
   - WeeklyCalendar refreshes on this event
   - Added notification icon for schedule revert

2. **Real-time updates**:
   - Calendar automatically refreshes when routines change
   - Shows notification with proper formatting

## Test Plan
- [ ] Apply a weekly routine and verify notifications are sent
- [ ] Revert a weekly routine and verify:
  - Users who had tasks get unassignment notifications
  - Mobile app shows notification
  - Calendar updates automatically
- [ ] Apply a day template with `replaceExisting=true` and verify proper notifications

## Screenshots
N/A - Backend and notification changes

🤖 Generated with [Claude Code](https://claude.ai/code)