### PR TITLE
Use task-specific icons in notifications

### DIFF
--- a/backend/src/services/websocket.service.ts
+++ b/backend/src/services/websocket.service.ts
@@ -298,6 +298,7 @@ export class WebSocketService {
   public notifyTaskReassigned(familyId: string, taskReassignmentData: {
     taskId: string;
     taskName: string;
+    taskIcon?: string;
     date: string;
     originalMemberId: string | null;
     newMemberId: string | null;
@@ -325,6 +326,7 @@ export class WebSocketService {
         familyId,
         taskId: taskReassignmentData.taskId,
         taskName: taskReassignmentData.taskName,
+        taskIcon: taskReassignmentData.taskIcon,
         date: taskReassignmentData.date,
         adminName: taskReassignmentData.adminName,
         message: `"${taskReassignmentData.taskName}" on ${taskReassignmentData.date} has been unassigned from you by ${taskReassignmentData.adminName}`,
@@ -338,6 +340,7 @@ export class WebSocketService {
         familyId,
         taskId: taskReassignmentData.taskId,
         taskName: taskReassignmentData.taskName,
+        taskIcon: taskReassignmentData.taskIcon,
         date: taskReassignmentData.date,
         adminName: taskReassignmentData.adminName,
         message: `"${taskReassignmentData.taskName}" on ${taskReassignmentData.date} has been assigned to you by ${taskReassignmentData.adminName}`,
@@ -350,6 +353,7 @@ export class WebSocketService {
       familyId,
       taskId: taskReassignmentData.taskId,
       taskName: taskReassignmentData.taskName,
+      taskIcon: taskReassignmentData.taskIcon,
       date: taskReassignmentData.date,
       originalMemberId: taskReassignmentData.originalMemberId,
       newMemberId: taskReassignmentData.newMemberId,

--- a/backend/src/services/week-schedule.service.ts
+++ b/backend/src/services/week-schedule.service.ts
@@ -697,6 +697,7 @@ export class WeekScheduleService {
         await webSocketService.notifyTaskReassigned(familyId, {
           taskId: override.taskId,
           taskName: override.task.name,
+          taskIcon: override.task.icon,
           date: formattedDate,
           originalMemberId: override.newMemberId, // They had it
           newMemberId: null, // Now no one has it
@@ -741,10 +742,10 @@ export class WeekScheduleService {
 
     // Process each override and send appropriate notifications
     for (const override of overrides) {
-      // Get task information
+      // Get task information including icon
       const task = await this.prisma.task.findUnique({
         where: { id: override.taskId },
-        select: { name: true },
+        select: { name: true, icon: true },
       });
 
       if (!task) {
@@ -769,6 +770,7 @@ export class WeekScheduleService {
             await webSocketService.notifyTaskReassigned(familyId, {
               taskId: override.taskId,
               taskName: task.name,
+              taskIcon: task.icon,
               date: formattedDate,
               originalMemberId: override.originalMemberId,
               newMemberId: override.newMemberId,
@@ -783,6 +785,7 @@ export class WeekScheduleService {
             await webSocketService.notifyTaskReassigned(familyId, {
               taskId: override.taskId,
               taskName: task.name,
+              taskIcon: task.icon,
               date: formattedDate,
               originalMemberId: null, // Task was added, not reassigned
               newMemberId: override.newMemberId,
@@ -797,6 +800,7 @@ export class WeekScheduleService {
             await webSocketService.notifyTaskReassigned(familyId, {
               taskId: override.taskId,
               taskName: task.name,
+              taskIcon: task.icon,
               date: formattedDate,
               originalMemberId: override.originalMemberId,
               newMemberId: null, // Task was removed

--- a/mobile/src/components/ui/UserMenu.tsx
+++ b/mobile/src/components/ui/UserMenu.tsx
@@ -180,6 +180,10 @@ export const UserMenu: React.FC<UserMenuProps> = ({
                     const config = NotificationService.getNotificationConfig(notification.type);
                     const formattedTime = NotificationService.formatTimestamp(notification.timestamp);
                     
+                    // Use task icon if available for task notifications
+                    const isTaskEvent = notification.type === 'task-assigned' || notification.type === 'task-unassigned';
+                    const icon = (isTaskEvent && notification.data?.taskIcon) ? notification.data.taskIcon : config.icon;
+                    
                     return (
                       <TouchableOpacity
                         key={notification.id}
@@ -190,7 +194,7 @@ export const UserMenu: React.FC<UserMenuProps> = ({
                         onPress={() => handleNotificationPress(notification.id)}
                       >
                         <Text style={styles.notificationIcon}>
-                          {config.icon}
+                          {icon}
                         </Text>
                         <View style={styles.notificationContent}>
                           <Text style={styles.notificationMessage}>

--- a/mobile/src/contexts/NotificationContext.tsx
+++ b/mobile/src/contexts/NotificationContext.tsx
@@ -72,8 +72,11 @@ export const NotificationProvider: React.FC<NotificationProviderProps> = ({ chil
       // Get notification config for better icons and formatting
       const config = NotificationService.getNotificationConfig(notification.type);
       
+      // Use task icon if available for task notifications
+      const icon = (isTaskEvent && notification.data?.taskIcon) ? notification.data.taskIcon : config.icon;
+      
       await NotificationService.showNotification({
-        title: `${config.icon} ${notification.title}`,
+        title: `${icon} ${notification.title}`,
         body: notification.message,
         data: notification.data,
       });

--- a/mobile/src/screens/NotificationScreen.tsx
+++ b/mobile/src/screens/NotificationScreen.tsx
@@ -29,6 +29,10 @@ interface NotificationItemProps {
 const NotificationItem: React.FC<NotificationItemProps> = ({ notification, onPress }) => {
   const config = NotificationService.getNotificationConfig(notification.type);
   const formattedTime = NotificationService.formatTimestamp(notification.timestamp);
+  
+  // Use task icon if available for task notifications
+  const isTaskEvent = notification.type === 'task-assigned' || notification.type === 'task-unassigned';
+  const icon = (isTaskEvent && notification.data?.taskIcon) ? notification.data.taskIcon : config.icon;
 
   return (
     <TouchableOpacity
@@ -41,7 +45,7 @@ const NotificationItem: React.FC<NotificationItemProps> = ({ notification, onPre
     >
       <View style={styles.notificationContent}>
         <View style={styles.notificationHeader}>
-          <Text style={styles.notificationIcon}>{config.icon}</Text>
+          <Text style={styles.notificationIcon}>{icon}</Text>
           <View style={styles.notificationMeta}>
             <Text style={styles.notificationTitle}>{notification.title}</Text>
             <Text style={styles.notificationTime}>{formattedTime}</Text>


### PR DESCRIPTION
## Summary
- Display task-specific emojis (🛁, 🍼, etc.) instead of generic icons in notifications
- Provides better visual context for users to quickly identify which task the notification is about
- Icons appear in push notifications, notification list, and user menu

## Changes Made

### Backend
- Updated `week-schedule.service.ts` to include task icon when fetching task information
- Modified `WebSocketService` to accept and pass `taskIcon` in notification data
- Updated all `notifyTaskReassigned` calls to include the task icon

### Mobile App  
- Enhanced notification display to use task icon when available for task events
- Updated three notification display locations:
  - Push notification popups (via `NotificationContext`)
  - Notification list screen (`NotificationScreen`)
  - User menu dropdown (`UserMenu`)

## Test Plan
- [x] Reassign a task and verify the notification shows the task's emoji
- [x] Check notification appears with task icon in:
  - [x] Push notification popup
  - [x] Notification list
  - [x] User menu dropdown
- [x] Verify non-task notifications still use default icons
- [x] Test task removal notifications also show task icons

## Screenshots
Task notifications now show the actual task emoji (e.g., 🛁 for Bath) instead of the generic 📋 icon, making it easier to identify tasks at a glance.

🤖 Generated with [Claude Code](https://claude.ai/code)