### PR TITLE
fix: add missing version field to Docker Compose files

### DIFF
--- a/.devcontainer/docker-compose.devcontainer.yml
+++ b/.devcontainer/docker-compose.devcontainer.yml
@@ -1,11 +1,13 @@
+version: '3.8'
+
 services:
   devcontainer:
     build:
-      context: .
+      context: ..
       dockerfile: Dockerfile.dev
     volumes:
       # Mount the entire workspace
-      - .:/workspace:cached
+      - ..:/workspace:cached
       # Persist bash history
       - bashhistory:/commandhistory
       # Persist extensions and VS Code server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+version: '3.8'
+
 services:
   postgres:
     image: postgres:15-alpine


### PR DESCRIPTION
## Summary
- Fix devcontainer error on other machines by adding missing version fields
- Correct build context and volume mount paths in devcontainer configuration

## Changes
- Add `version: '3.8'` to `docker-compose.yml`
- Add `version: '3.8'` to `.devcontainer/docker-compose.devcontainer.yml`
- Fix build context path from `.` to `..` (to access Dockerfile.dev in root)
- Fix volume mount path from `.` to `..` (to match the context change)

## Test plan
- [ ] Open project in VS Code on a different machine
- [ ] Select "Reopen in Container" 
- [ ] Verify dev container builds and starts successfully
- [ ] Verify all services are accessible

🤖 Generated with [Claude Code](https://claude.ai/code)