### PR TITLE
fix: remove non-existent postgres-asdf feature from devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,8 +9,7 @@
 
   "features": {
     "ghcr.io/devcontainers/features/git:1": {},
-    "ghcr.io/devcontainers/features/github-cli:1": {},
-    "ghcr.io/devcontainers-community/features/postgres-asdf:1": {}
+    "ghcr.io/devcontainers/features/github-cli:1": {}
   },
 
   "customizations": {


### PR DESCRIPTION
## Summary
Remove the postgres-asdf feature that's causing devcontainer build failures.

## Problem
The devcontainer fails to build with the error:
```
Could not resolve Feature manifest for 'ghcr.io/devcontainers-community/features/postgres-asdf:1'
```

## Solution
Remove the non-existent `postgres-asdf` feature from `devcontainer.json`. 

PostgreSQL client tools are already being installed via `apt-get install postgresql-client` in the post-create script, so this feature is not needed.

## Test Plan
- [ ] Open project in VS Code
- [ ] Click "Reopen in Container"
- [ ] Verify devcontainer builds successfully
- [ ] Verify PostgreSQL client tools are available (`pg_dump`, `pg_restore`, `psql`)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>