### PR TITLE
feat: add comprehensive SSL setup for NAS deployment

### DIFF
--- a/SETUP-DOMAIN-NAS.md
+++ b/SETUP-DOMAIN-NAS.md
@@ -1,0 +1,121 @@
+# Setting Up Domain Access for NAS-hosted Family Board
+
+## Prerequisites
+- Family Board running on your NAS
+- Access to Livebox admin panel
+- AWS Route53 access
+- Domain name (e.g., mabt.eu)
+
+## Step 1: Configure Livebox Port Forwarding
+
+1. Access Livebox admin: `http://192.168.1.1`
+2. Go to **Configuration** → **Réseau** → **NAT/PAT**
+3. Add port forwarding rules:
+   - External Port 80 → NAS_IP:80 (TCP)
+   - External Port 443 → NAS_IP:443 (TCP)
+4. Save configuration
+
+## Step 2: Get Your Public IP
+
+```bash
+curl ifconfig.me
+```
+
+Note: Orange typically provides dynamic IPs. Consider:
+- Setting up DuckDNS for automatic updates
+- Or manually update when IP changes
+
+## Step 3: Configure Route53
+
+1. Log into AWS Console → Route53
+2. Select your hosted zone (mabt.eu)
+3. Create/Update A record:
+   - Name: `@` or `nas`
+   - Type: A
+   - Value: Your public IP
+   - TTL: 300
+
+## Step 4: Update NAS Configuration
+
+1. SSH into your NAS
+2. Navigate to project directory
+3. Update `.env.nas`:
+   ```env
+   VITE_API_URL=https://mabt.eu
+   ```
+
+## Step 5: Set Up SSL Certificates
+
+1. First-time setup:
+   ```bash
+   # On your NAS
+   cd /path/to/family-board
+   ./scripts/setup-ssl-nas.sh
+   ```
+
+2. Update email in the script first!
+
+## Step 6: Deploy with SSL
+
+```bash
+# Stop current deployment
+docker-compose -f docker-compose.nas.yml down
+
+# Copy nginx config
+cp nginx/nginx-nas.conf nginx/nginx-ssl.conf
+
+# Start with SSL
+docker-compose -f docker-compose.nas.yml up -d
+```
+
+## Step 7: Test Access
+
+1. Test HTTP redirect: `http://mabt.eu` → should redirect to HTTPS
+2. Test HTTPS: `https://mabt.eu` → should show your app
+3. Test API: `https://mabt.eu/api/health`
+
+## Troubleshooting
+
+### "Connection Refused"
+- Check Livebox port forwarding
+- Verify NAS firewall allows 80/443
+- Check Docker containers are running
+
+### "SSL Certificate Error"
+- Ensure domain DNS has propagated (can take up to 48h)
+- Check certbot logs: `docker logs family-board-certbot`
+
+### Dynamic IP Changes
+Set up a cron job on your NAS:
+```bash
+# Add to crontab
+*/30 * * * * /path/to/family-board/scripts/update-route53.sh
+```
+
+## Security Considerations
+
+1. **Enable Livebox Firewall**
+   - Only allow ports 80 and 443
+   - Block all other incoming connections
+
+2. **Use Strong Passwords**
+   - Update all default passwords in `.env.nas`
+   - Use strong JWT secret
+
+3. **Regular Updates**
+   - Keep Docker images updated
+   - Monitor security advisories
+
+## Maintenance
+
+### Renew SSL Certificates
+Certbot container handles this automatically, but you can force renewal:
+```bash
+docker-compose -f docker-compose.nas.yml exec certbot certbot renew --force-renewal
+docker-compose -f docker-compose.nas.yml restart nginx
+```
+
+### Monitor Logs
+```bash
+docker-compose -f docker-compose.nas.yml logs -f nginx certbot
+```

--- a/docker-compose.nas.yml
+++ b/docker-compose.nas.yml
@@ -77,6 +77,14 @@ services:
     restart: unless-stopped
     command: "/bin/sh -c 'while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g \"daemon off;\"'"
 
+  certbot:
+    image: certbot/certbot
+    container_name: family-board-certbot
+    volumes:
+      - ./certbot/conf:/etc/letsencrypt
+      - ./certbot/www:/var/www/certbot
+    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
+
 volumes:
   postgres_data:
 

--- a/nginx/nginx-http-only.conf
+++ b/nginx/nginx-http-only.conf
@@ -1,0 +1,58 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    upstream backend {
+        server backend:3001;
+    }
+
+    upstream frontend {
+        server frontend:80;
+    }
+
+    # HTTP server for initial setup and ACME challenge
+    server {
+        listen 80;
+        server_name mabt.eu www.mabt.eu;
+        
+        # ACME challenge location
+        location /.well-known/acme-challenge/ {
+            root /var/www/certbot;
+        }
+        
+        # API routes
+        location /api {
+            proxy_pass http://backend;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection 'upgrade';
+            proxy_set_header Host $host;
+            proxy_cache_bypass $http_upgrade;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # Socket.io
+        location /socket.io {
+            proxy_pass http://backend;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # Frontend
+        location / {
+            proxy_pass http://frontend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}

--- a/nginx/nginx-nas.conf
+++ b/nginx/nginx-nas.conf
@@ -1,0 +1,81 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    upstream backend {
+        server backend:3001;
+    }
+
+    upstream frontend {
+        server frontend:80;
+    }
+
+    # Redirect HTTP to HTTPS
+    server {
+        listen 80;
+        server_name mabt.eu nas.mabt.eu;
+        
+        location /.well-known/acme-challenge/ {
+            root /var/www/certbot;
+        }
+        
+        location / {
+            return 301 https://$host$request_uri;
+        }
+    }
+
+    # HTTPS configuration
+    server {
+        listen 443 ssl;
+        server_name mabt.eu nas.mabt.eu;
+
+        # SSL certificates (will be created by certbot)
+        ssl_certificate /etc/letsencrypt/live/mabt.eu/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/mabt.eu/privkey.pem;
+        
+        # SSL configuration
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384;
+        ssl_prefer_server_ciphers off;
+
+        # Security headers
+        add_header Strict-Transport-Security "max-age=63072000" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+
+        # API routes
+        location /api {
+            proxy_pass http://backend;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection 'upgrade';
+            proxy_set_header Host $host;
+            proxy_cache_bypass $http_upgrade;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # Socket.io
+        location /socket.io {
+            proxy_pass http://backend;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # Frontend
+        location / {
+            proxy_pass http://frontend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}

--- a/scripts/diagnose-ssl-setup.sh
+++ b/scripts/diagnose-ssl-setup.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Diagnose SSL setup issues
+
+echo "🔍 Diagnosing SSL setup issues..."
+echo "================================"
+
+# Check public IP
+echo "📡 Your public IP address:"
+curl -s https://api.ipify.org
+echo -e "\n"
+
+# Check DNS records
+echo "🌐 DNS records for mabt.eu:"
+nslookup mabt.eu 8.8.8.8
+echo ""
+echo "🌐 DNS records for www.mabt.eu:"
+nslookup www.mabt.eu 8.8.8.8
+echo ""
+
+# Test port 80 connectivity
+echo "🔌 Testing port 80 connectivity from outside:"
+echo "Running: curl -I http://mabt.eu/.well-known/acme-challenge/test"
+timeout 10 curl -I http://mabt.eu/.well-known/acme-challenge/test || echo "❌ Port 80 appears to be blocked or unreachable"
+echo ""
+
+# Check local services
+echo "🐳 Docker services status:"
+docker-compose -f docker-compose.nas.yml ps
+echo ""
+
+# Check if nginx is listening on port 80
+echo "🔍 Checking if nginx is listening on port 80:"
+docker-compose -f docker-compose.nas.yml exec nginx netstat -tlnp | grep :80 || echo "Nginx might not be running"
+echo ""
+
+echo "📋 Checklist for SSL setup:"
+echo "1. ✓ Is port 80 forwarded from your router to your NAS?"
+echo "2. ✓ Is port 443 forwarded from your router to your NAS?"
+echo "3. ✓ Are firewall rules allowing incoming HTTP/HTTPS traffic?"
+echo "4. ✓ Do DNS records point to your public IP (shown above)?"
+echo "5. ✓ Is your ISP blocking port 80? (some residential ISPs do this)"
+echo ""
+echo "💡 If your ISP blocks port 80, consider:"
+echo "   - Using DNS validation instead of HTTP validation"
+echo "   - Using a different port with a reverse proxy service"
+echo "   - Contacting your ISP to unblock port 80"

--- a/scripts/init-ssl-nas.sh
+++ b/scripts/init-ssl-nas.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+# Initialize SSL setup for NAS - handles the chicken-and-egg problem
+
+set -e
+
+DOMAIN="mabt.eu"
+EMAIL="your-email@example.com"  # IMPORTANT: Change this to your email!
+
+echo "🚀 Initializing SSL setup for Family Board on NAS"
+echo "=================================================="
+echo ""
+
+# Check if email was changed
+if [ "$EMAIL" = "your-email@example.com" ]; then
+    echo "❌ ERROR: Please edit this script and set your email address!"
+    echo "   Edit line 7 of this script and replace 'your-email@example.com' with your actual email"
+    exit 1
+fi
+
+# Create required directories
+echo "📁 Creating required directories..."
+mkdir -p certbot/conf
+mkdir -p certbot/www
+mkdir -p nginx
+
+# Step 1: Start with HTTP-only configuration
+echo "🔧 Step 1: Starting services with HTTP-only configuration..."
+# Backup current docker-compose if it exists
+if [ -f docker-compose.nas.yml ]; then
+    cp docker-compose.nas.yml docker-compose.nas.yml.backup
+fi
+
+# Temporarily modify docker-compose to use HTTP-only config
+sed -i.tmp 's|./nginx/nginx-ssl.conf:|./nginx/nginx-http-only.conf:|' docker-compose.nas.yml
+
+# Stop any running services
+docker-compose -f docker-compose.nas.yml down
+
+# Start services with HTTP-only config
+docker-compose -f docker-compose.nas.yml up -d
+
+# Wait for services to be ready
+echo "⏳ Waiting for services to start..."
+sleep 15
+
+# Check if nginx is running
+if ! docker-compose -f docker-compose.nas.yml ps | grep -q "nginx.*Up"; then
+    echo "❌ ERROR: Nginx failed to start. Check logs with:"
+    echo "   docker-compose -f docker-compose.nas.yml logs nginx"
+    exit 1
+fi
+
+# Step 2: Test HTTP connectivity
+echo ""
+echo "🔍 Step 2: Testing HTTP connectivity..."
+echo "Testing local connectivity..."
+if curl -f -s -o /dev/null http://localhost/.well-known/acme-challenge/test; then
+    echo "✅ Local HTTP connectivity OK"
+else
+    echo "⚠️  Local HTTP connectivity failed - nginx might not be properly configured"
+fi
+
+echo ""
+echo "Testing external connectivity to $DOMAIN..."
+if timeout 10 curl -f -s -o /dev/null http://$DOMAIN/.well-known/acme-challenge/test 2>/dev/null; then
+    echo "✅ External HTTP connectivity OK"
+else
+    echo "❌ ERROR: Cannot reach $DOMAIN from the internet"
+    echo ""
+    echo "Please check:"
+    echo "1. Port 80 is forwarded from your router to your NAS"
+    echo "2. Your firewall allows incoming connections on port 80"
+    echo "3. DNS records for $DOMAIN point to your public IP"
+    echo ""
+    echo "Run ./scripts/diagnose-ssl-setup.sh for more details"
+    exit 1
+fi
+
+# Step 3: Obtain SSL certificates
+echo ""
+echo "🔐 Step 3: Obtaining SSL certificates..."
+docker run --rm \
+  -v $(pwd)/certbot/conf:/etc/letsencrypt \
+  -v $(pwd)/certbot/www:/var/www/certbot \
+  --network family-board-network \
+  certbot/certbot certonly \
+  --webroot \
+  --webroot-path /var/www/certbot \
+  --email $EMAIL \
+  --agree-tos \
+  --no-eff-email \
+  --force-renewal \
+  -d $DOMAIN \
+  -d www.$DOMAIN
+
+# Check if certificates were obtained
+if [ ! -f "certbot/conf/live/$DOMAIN/fullchain.pem" ]; then
+    echo "❌ Failed to obtain SSL certificates!"
+    exit 1
+fi
+
+echo "✅ SSL certificates obtained successfully!"
+
+# Step 4: Switch to SSL configuration
+echo ""
+echo "🔄 Step 4: Switching to SSL configuration..."
+# Create the SSL nginx config
+cp nginx/nginx-nas.conf nginx/nginx-ssl.conf
+
+# Update docker-compose to use SSL config
+sed -i.tmp 's|./nginx/nginx-http-only.conf:|./nginx/nginx-ssl.conf:|' docker-compose.nas.yml
+
+# Restart services with SSL
+docker-compose -f docker-compose.nas.yml down
+docker-compose -f docker-compose.nas.yml up -d
+
+# Wait for services to restart
+echo "⏳ Waiting for services to restart with SSL..."
+sleep 10
+
+# Verify SSL is working
+echo ""
+echo "🔍 Verifying SSL setup..."
+if curl -f -s -o /dev/null https://$DOMAIN 2>/dev/null; then
+    echo "✅ HTTPS is working!"
+else
+    echo "⚠️  HTTPS might not be working yet. This could be normal if DNS is still propagating."
+fi
+
+echo ""
+echo "✅ SSL setup complete!"
+echo ""
+echo "📋 Next steps:"
+echo "1. Make sure port 443 is forwarded from your router to your NAS"
+echo "2. Your site should be accessible at:"
+echo "   - https://$DOMAIN"
+echo "   - https://www.$DOMAIN"
+echo ""
+echo "🔄 Certificates will auto-renew via the certbot container"
+echo ""
+echo "📝 To check service status:"
+echo "   docker-compose -f docker-compose.nas.yml ps"
+echo ""
+echo "📝 To view logs:"
+echo "   docker-compose -f docker-compose.nas.yml logs"
+
+# Cleanup
+rm -f docker-compose.nas.yml.tmp nginx/*.tmp

--- a/scripts/setup-ssl-nas-dns.sh
+++ b/scripts/setup-ssl-nas-dns.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Setup SSL certificates using DNS validation (no port 80 required)
+
+set -e
+
+DOMAIN="mabt.eu"
+EMAIL="your-email@example.com"  # Change this!
+
+echo "🔐 Setting up SSL certificates for $DOMAIN using DNS validation"
+echo "This method doesn't require port 80 to be open!"
+echo ""
+
+# Create certbot directories
+mkdir -p certbot/conf
+mkdir -p certbot/www
+
+# Run certbot with DNS challenge
+echo "🔒 Starting DNS validation process..."
+echo "You will need to add TXT records to your DNS configuration."
+echo ""
+
+docker run -it --rm \
+  -v $(pwd)/certbot/conf:/etc/letsencrypt \
+  -v $(pwd)/certbot/www:/var/www/certbot \
+  certbot/certbot certonly \
+  --manual \
+  --preferred-challenges dns \
+  --email $EMAIL \
+  --agree-tos \
+  --no-eff-email \
+  -d $DOMAIN \
+  -d www.$DOMAIN \
+  -d "*.${DOMAIN}"
+
+# Check if certificates were obtained
+if [ ! -f "certbot/conf/live/$DOMAIN/fullchain.pem" ]; then
+    echo "❌ Failed to obtain SSL certificates!"
+    exit 1
+fi
+
+# Copy nginx SSL config
+cp nginx/nginx-nas.conf nginx/nginx-ssl.conf
+
+# Start services with SSL
+echo "✅ Certificates obtained! Starting services with SSL..."
+docker-compose -f docker-compose.nas.yml up -d
+
+echo "✅ SSL setup complete!"
+echo "Your site should now be accessible at https://$DOMAIN"
+echo ""
+echo "⚠️  Important: Make sure port 443 is forwarded to your NAS!"

--- a/scripts/setup-ssl-nas-webroot.sh
+++ b/scripts/setup-ssl-nas-webroot.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Setup SSL certificates for NAS deployment using webroot mode
+
+set -e
+
+DOMAIN="mabt.eu"
+EMAIL="your-email@example.com"  # Change this!
+
+echo "🔐 Setting up SSL certificates for $DOMAIN using webroot mode"
+
+# Create certbot directories
+mkdir -p certbot/conf
+mkdir -p certbot/www
+
+# First, ensure nginx is running with HTTP only config
+echo "📝 Creating initial HTTP-only nginx config..."
+cat > nginx/nginx-http-only.conf << 'EOF'
+events {
+    worker_connections 1024;
+}
+
+http {
+    upstream backend {
+        server backend:3001;
+    }
+
+    upstream frontend {
+        server frontend:80;
+    }
+
+    # HTTP server for ACME challenge
+    server {
+        listen 80;
+        server_name mabt.eu www.mabt.eu;
+        
+        location /.well-known/acme-challenge/ {
+            root /var/www/certbot;
+        }
+        
+        location / {
+            proxy_pass http://frontend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}
+EOF
+
+# Update docker-compose to use HTTP-only config temporarily
+sed -i.bak 's|./nginx/nginx-ssl.conf:|./nginx/nginx-http-only.conf:|' docker-compose.nas.yml
+
+# Start services with HTTP-only config
+echo "🚀 Starting services with HTTP-only configuration..."
+docker-compose -f docker-compose.nas.yml up -d
+
+# Wait for services to be ready
+echo "⏳ Waiting for services to start..."
+sleep 10
+
+# Run certbot in webroot mode
+echo "🔒 Obtaining SSL certificates..."
+docker-compose -f docker-compose.nas.yml exec -T nginx certbot certonly \
+  --webroot \
+  --webroot-path /var/www/certbot \
+  --email $EMAIL \
+  --agree-tos \
+  --no-eff-email \
+  --force-renewal \
+  -d $DOMAIN \
+  -d www.$DOMAIN
+
+# Check if certificates were obtained
+if [ ! -f "certbot/conf/live/$DOMAIN/fullchain.pem" ]; then
+    echo "❌ Failed to obtain SSL certificates!"
+    echo "Please check:"
+    echo "1. Port 80 is forwarded from your router to your NAS"
+    echo "2. Firewall allows incoming connections on port 80"
+    echo "3. DNS records for $DOMAIN point to your public IP"
+    exit 1
+fi
+
+# Revert to SSL config
+echo "✅ Certificates obtained! Switching to SSL configuration..."
+sed -i.bak 's|./nginx/nginx-http-only.conf:|./nginx/nginx-ssl.conf:|' docker-compose.nas.yml
+cp nginx/nginx-nas.conf nginx/nginx-ssl.conf
+
+# Restart services with SSL
+docker-compose -f docker-compose.nas.yml up -d
+
+echo "✅ SSL setup complete!"
+echo "Your site should now be accessible at https://$DOMAIN"
+echo ""
+echo "⚠️  Important: Make sure port 443 is also forwarded to your NAS!"

--- a/scripts/setup-ssl-nas.sh
+++ b/scripts/setup-ssl-nas.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Setup SSL certificates for NAS deployment
+
+set -e
+
+DOMAIN="mabt.eu"
+EMAIL="your-email@example.com"  # Change this!
+
+echo "🔐 Setting up SSL certificates for $DOMAIN"
+
+# Stop nginx to free port 80
+docker-compose -f docker-compose.nas.yml stop nginx
+
+# Run certbot
+docker run --rm \
+  -v $(pwd)/certbot/conf:/etc/letsencrypt \
+  -v $(pwd)/certbot/www:/var/www/certbot \
+  -p 80:80 \
+  certbot/certbot certonly \
+  --standalone \
+  --email $EMAIL \
+  --agree-tos \
+  --no-eff-email \
+  -d $DOMAIN \
+  -d nas.$DOMAIN
+
+# Update nginx config to use the new certificate
+cp nginx/nginx-nas.conf nginx/nginx-ssl.conf
+
+# Start services with SSL
+docker-compose -f docker-compose.nas.yml up -d
+
+echo "✅ SSL setup complete!"
+echo "Your site should now be accessible at https://$DOMAIN"

--- a/scripts/update-route53.sh
+++ b/scripts/update-route53.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Script to update Route53 with your home IP
+
+# Configuration
+HOSTED_ZONE_ID="YOUR_HOSTED_ZONE_ID"  # Found in Route53 console
+DOMAIN="mabt.eu"                      # Your domain
+RECORD_NAME="nas.mabt.eu"             # Subdomain for NAS
+TTL=300
+
+# Get current public IP
+CURRENT_IP=$(curl -s ifconfig.me)
+echo "Current public IP: $CURRENT_IP"
+
+# Create JSON for Route53 update
+cat > /tmp/route53-change.json << EOF
+{
+  "Changes": [
+    {
+      "Action": "UPSERT",
+      "ResourceRecordSet": {
+        "Name": "$RECORD_NAME",
+        "Type": "A",
+        "TTL": $TTL,
+        "ResourceRecords": [
+          {
+            "Value": "$CURRENT_IP"
+          }
+        ]
+      }
+    }
+  ]
+}
+EOF
+
+# Update Route53
+aws route53 change-resource-record-sets \
+  --hosted-zone-id $HOSTED_ZONE_ID \
+  --change-batch file:///tmp/route53-change.json
+
+echo "Route53 updated with IP: $CURRENT_IP"
+
+# Clean up
+rm /tmp/route53-change.json


### PR DESCRIPTION
## Summary
- Adds complete SSL setup solution for NAS deployment with Let's Encrypt
- Solves the chicken-and-egg problem where nginx won't start without certificates
- Provides multiple setup methods and troubleshooting tools

## Changes
- **init-ssl-nas.sh**: Main initialization script that handles the complete SSL setup flow
- **nginx-http-only.conf**: HTTP-only configuration for initial setup phase
- **diagnose-ssl-setup.sh**: Diagnostic script to troubleshoot connectivity issues
- **Multiple setup methods**: Webroot and DNS validation alternatives
- **Comprehensive documentation**: SETUP-DOMAIN-NAS.md with full setup instructions

## Key Features
1. **Automatic handling of missing certificates**: The init script starts nginx without SSL first, obtains certificates, then switches to SSL
2. **Built-in diagnostics**: Check connectivity, DNS, and port forwarding before attempting SSL
3. **Multiple validation methods**: Support for both HTTP-01 (webroot) and DNS-01 challenges
4. **Auto-renewal**: Configured certbot container for automatic certificate renewal

## Test Plan
- [ ] Run init-ssl-nas.sh on a fresh NAS setup
- [ ] Verify nginx starts successfully without certificates
- [ ] Confirm SSL certificates are obtained from Let's Encrypt
- [ ] Test HTTPS access to the domain
- [ ] Verify auto-renewal is configured

## Usage
1. Edit `scripts/init-ssl-nas.sh` and set your email address
2. Ensure ports 80 and 443 are forwarded to your NAS
3. Run: `./scripts/init-ssl-nas.sh`

🤖 Generated with [Claude Code](https://claude.ai/code)