### PR TITLE
fix: resolve certbot hanging issue and remove obsolete version attribute

### DIFF
--- a/docker-compose.nas.yml
+++ b/docker-compose.nas.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   postgres:
     image: postgres:15-alpine

--- a/scripts/get-ssl-manual.sh
+++ b/scripts/get-ssl-manual.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Manual SSL certificate generation script
+
+DOMAIN="mabt.eu"
+EMAIL="your-email@example.com"  # CHANGE THIS!
+
+echo "Manual SSL Certificate Generation"
+echo "================================="
+echo ""
+echo "This script will obtain SSL certificates using the running nginx container."
+echo ""
+
+# Check if email was changed
+if [ "$EMAIL" = "your-email@example.com" ]; then
+    echo "❌ ERROR: Please edit this script and set your email address!"
+    exit 1
+fi
+
+# Check if nginx is running
+if ! docker ps | grep -q family-board-nginx; then
+    echo "❌ ERROR: Nginx container is not running!"
+    echo "Start it with: docker-compose -f docker-compose.nas.yml up -d nginx"
+    exit 1
+fi
+
+echo "Running certbot to obtain certificates..."
+echo ""
+
+# Run certbot
+docker run -it --rm \
+  -v $(pwd)/certbot/conf:/etc/letsencrypt \
+  -v $(pwd)/certbot/www:/var/www/certbot \
+  --network container:family-board-nginx \
+  certbot/certbot certonly \
+  --webroot \
+  --webroot-path /var/www/certbot \
+  --email $EMAIL \
+  --agree-tos \
+  --no-eff-email \
+  -d $DOMAIN \
+  -d www.$DOMAIN
+
+# Check if successful
+if [ -f "certbot/conf/live/$DOMAIN/fullchain.pem" ]; then
+    echo ""
+    echo "✅ SSL certificates obtained successfully!"
+    echo ""
+    echo "Next steps:"
+    echo "1. Update nginx config to use SSL (already done in nginx-nas.conf)"
+    echo "2. Restart nginx with SSL config:"
+    echo "   docker-compose -f docker-compose.nas.yml restart nginx"
+else
+    echo ""
+    echo "❌ Failed to obtain certificates"
+    echo "Check the error messages above"
+fi

--- a/scripts/init-ssl-nas.sh
+++ b/scripts/init-ssl-nas.sh
@@ -87,17 +87,19 @@ fi
 # Step 3: Obtain SSL certificates
 echo ""
 echo "🔐 Step 3: Obtaining SSL certificates..."
-# Use docker-compose exec to run certbot with proper network context
-docker-compose -f docker-compose.nas.yml run --rm \
+# Run certbot using the existing network and nginx setup
+docker run --rm \
   -v $(pwd)/certbot/conf:/etc/letsencrypt \
   -v $(pwd)/certbot/www:/var/www/certbot \
-  certbot certonly \
+  --network container:family-board-nginx \
+  certbot/certbot certonly \
   --webroot \
   --webroot-path /var/www/certbot \
   --email $EMAIL \
   --agree-tos \
   --no-eff-email \
-  --force-renewal \
+  --non-interactive \
+  --keep-until-expiring \
   -d $DOMAIN \
   -d www.$DOMAIN
 


### PR DESCRIPTION
## Summary
- Fixes certbot hanging during SSL certificate generation
- Removes obsolete version attribute from docker-compose.nas.yml
- Adds manual SSL generation script for troubleshooting

## Problem
The init-ssl-nas.sh script was hanging because:
1. The certbot command was using `docker-compose run` incorrectly
2. Certbot was running in renewal mode instead of obtaining new certificates
3. The version attribute in docker-compose.nas.yml is obsolete and causing warnings

## Solution
- Use `--network container:family-board-nginx` to connect certbot to the existing nginx network
- Use `--keep-until-expiring` instead of `--force-renewal` to properly handle certificate requests
- Add `--non-interactive` flag to prevent hanging on prompts
- Remove the obsolete `version: '3.8'` from docker-compose.nas.yml
- Add get-ssl-manual.sh script for manual certificate generation

## Test Plan
- [ ] Run init-ssl-nas.sh and verify it doesn't hang
- [ ] Confirm certbot obtains certificates successfully
- [ ] Verify no more version warnings from docker-compose
- [ ] Test manual SSL script as fallback option

## For immediate use
While waiting for PR merge, you can use the manual script:
```bash
# Edit the script to set your email
nano scripts/get-ssl-manual.sh
# Run it
./scripts/get-ssl-manual.sh
```

🤖 Generated with [Claude Code](https://claude.ai/code)