### PR TITLE
fix: Add Prisma 6 connection pool configuration

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,9 +3,10 @@
 
 # Database Connection
 # In Podman, use 'postgres' as host. For local development, use 'localhost'
-DATABASE_URL=postgresql://postgres:change-me-in-production@postgres:5432/familyboard
+# Prisma 6 optimized connection pool settings for concurrent requests
+DATABASE_URL=postgresql://postgres:change-me-in-production@postgres:5432/familyboard?connection_limit=20&pool_timeout=30
 # Database URL for host machine (Prisma commands from outside container)
-DATABASE_URL_HOST=postgresql://postgres:change-me-in-production@localhost:5432/familyboard
+DATABASE_URL_HOST=postgresql://postgres:change-me-in-production@localhost:5432/familyboard?connection_limit=20&pool_timeout=30
 
 # Security
 # JWT_SECRET must be at least 32 characters long

--- a/backend/.env.production
+++ b/backend/.env.production
@@ -2,7 +2,8 @@
 # Copy this file to .env and update the values
 
 # Database Connection
-DATABASE_URL=postgresql://postgres:${DB_PASSWORD}@postgres:5432/familyboard
+# Prisma 6 optimized connection pool settings for concurrent requests
+DATABASE_URL=postgresql://postgres:${DB_PASSWORD}@postgres:5432/familyboard?connection_limit=20&pool_timeout=30
 
 # Security
 JWT_SECRET=${JWT_SECRET}


### PR DESCRIPTION
## Problem
After upgrading from Prisma 5 to Prisma 6, the application started experiencing hanging issues with concurrent database requests. The frontend would make multiple simultaneous API calls that would hang indefinitely.

## Root Cause
Prisma 6 introduced changes to connection pooling behavior. Without explicit connection pool configuration, concurrent requests would overwhelm the default connection handling.

## Solution
Added Prisma 6 optimized connection pool settings to environment files:
- `connection_limit=20` - Allows up to 20 concurrent database connections
- `pool_timeout=30` - 30 second timeout for connection pool requests

## Files Changed
- `backend/.env.example` - Updated DATABASE_URL with connection pool parameters
- `backend/.env.production` - Updated DATABASE_URL with connection pool parameters

## Testing
✅ Concurrent requests now complete successfully
✅ No more hanging on authentication or family queries  
✅ Frontend loads properly with multiple simultaneous API calls

This is the minimal fix needed for Prisma 6 compatibility.