### PR TITLE
fix: Add packages write permission for GHCR publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,7 +323,10 @@ jobs:
     name: "Build & Push Container Images"
     runs-on: ubuntu-latest
     needs: [lint, unit-tests-backend, unit-tests-frontend, build, e2e-tests]
-    if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/fix/clean-ci-keep-parallelization') && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    permissions:
+      contents: read
+      packages: write
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Fix GHCR permission denied error by adding packages:write permission to the build job