### PR TITLE
fix: Enable hot reload for frontend development in Podman containers

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,9 +7,16 @@ export default defineConfig({
   server: {
     host: '0.0.0.0',
     port: 3000,
+    watch: {
+      usePolling: true,
+      interval: 1000,
+    },
+    hmr: {
+      port: 3000,
+    },
   },
   preview: {
     host: '0.0.0.0',
     port: 3000,
   },
-}) 
+})

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -54,6 +54,10 @@ services:
     environment:
       # Pass through root-level CSRF configuration
       VITE_DISABLE_CSRF_VALIDATION: ${DISABLE_CSRF_VALIDATION:-false}
+      # File watching environment variables for containers
+      CHOKIDAR_USEPOLLING: "true"
+      CHOKIDAR_INTERVAL: 1000
+      WATCHPACK_POLLING: "true"
     depends_on:
       - backend
     volumes:


### PR DESCRIPTION
- Configure Vite to use polling-based file watching for container environments
- Add file watching environment variables (CHOKIDAR_USEPOLLING, WATCHPACK_POLLING)
- Set polling interval to 1000ms for optimal performance
- Configure HMR port explicitly for container networking

This resolves the issue where frontend file changes required container rebuilds instead of automatic hot reloading during development.