### PR TITLE
feat: Centralize shift status logic in backend API

### DIFF
--- a/backend/src/__tests__/unit/week-schedule.service.test.ts
+++ b/backend/src/__tests__/unit/week-schedule.service.test.ts
@@ -631,4 +631,46 @@ describe('WeekScheduleService', () => {
       ).rejects.toThrow('Invalid week start date format');
     });
   });
-}); 
+
+  describe('getShiftStatus', () => {
+    it('should return null when no week schedule exists', async () => {
+      const familyId = 'family-1';
+      const userId = 'user-1';
+
+      // Mock getWeekSchedule to return empty schedule
+      jest.spyOn(weekScheduleService, 'getWeekSchedule').mockResolvedValue({
+        familyId: 'family-1',
+        weekStartDate: new Date('2024-01-01'),
+        days: [],
+        hasOverrides: false
+      });
+
+      const result = await weekScheduleService.getShiftStatus(familyId, userId, {});
+
+      expect(result).toBeNull();
+    });
+
+    it('should handle getShiftStatus method call without errors', async () => {
+      const familyId = 'family-1';
+      const userId = 'user-1';
+
+      // Mock getWeekSchedule to return a basic schedule
+      jest.spyOn(weekScheduleService, 'getWeekSchedule').mockResolvedValue({
+        familyId: 'family-1',
+        weekStartDate: new Date('2024-01-01'),
+        days: [{
+          date: new Date('2024-01-01'),
+          dayOfWeek: 1,
+          tasks: []
+        }],
+        hasOverrides: false
+      });
+
+      // This should not throw an error
+      const result = await weekScheduleService.getShiftStatus(familyId, userId, {});
+
+      // Result can be null or a ShiftInfo object, both are valid
+      expect(result === null || typeof result === 'object').toBe(true);
+    });
+  });
+});

--- a/backend/src/routes/week-schedule.routes.ts
+++ b/backend/src/routes/week-schedule.routes.ts
@@ -58,7 +58,11 @@ router.get('/:familyId/shift-status', async (req: AuthenticatedRequest, res: Res
     const userId = req.user!.userId;
     await checkFamilyMembership(userId, familyId);
 
-    const shiftInfo = await weekScheduleService.getShiftStatus(familyId, userId, { weekStartDate });
+    const shiftInfo = await weekScheduleService.getShiftStatus(
+      familyId,
+      userId,
+      weekStartDate ? { weekStartDate } : {}
+    );
 
     if (!shiftInfo) {
       return res.status(200).json({ shiftInfo: null });

--- a/backend/src/routes/week-schedule.routes.ts
+++ b/backend/src/routes/week-schedule.routes.ts
@@ -2,9 +2,10 @@ import { Router, Response } from 'express';
 import { AuthenticatedRequest } from '../middleware/auth.middleware';
 import { WeekScheduleService } from '../services/week-schedule.service';
 import { PrismaClient } from '@prisma/client';
-import { 
+import {
   WeekScheduleQueryParams,
   ApplyWeekOverrideDto,
+  ShiftStatusQueryParams,
 } from '../types/task.types';
 
 const router = Router();
@@ -37,6 +38,71 @@ async function checkFamilyAdmin(userId: string, familyId: string): Promise<void>
     throw new Error('Access denied: Only family admins can perform this action');
   }
 }
+
+// ==================== SHIFT STATUS ROUTES ====================
+
+/**
+ * GET /api/families/:familyId/shift-status
+ * Get the current shift status for the authenticated user
+ */
+router.get('/:familyId/shift-status', async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const { familyId } = req.params;
+    const { weekStartDate } = req.query as Partial<ShiftStatusQueryParams>;
+
+    if (!familyId) {
+      return res.status(400).json({ error: 'Family ID is required' });
+    }
+
+    // Verify user has access to this family
+    const userId = req.user!.userId;
+    await checkFamilyMembership(userId, familyId);
+
+    const shiftInfo = await weekScheduleService.getShiftStatus(familyId, userId, { weekStartDate });
+
+    if (!shiftInfo) {
+      return res.status(200).json({ shiftInfo: null });
+    }
+
+    const response = {
+      shiftInfo: {
+        type: shiftInfo.type,
+        startTime: shiftInfo.startTime?.toISOString(),
+        endTime: shiftInfo.endTime?.toISOString(),
+        timeUntilStart: shiftInfo.timeUntilStart,
+        timeRemaining: shiftInfo.timeRemaining,
+      }
+    };
+
+    return res.status(200).json(response);
+  } catch (error) {
+    console.log('=== SHIFT STATUS ERROR ===');
+    console.log('Error type:', error?.constructor?.name);
+    console.log('Error message:', (error as any)?.message);
+
+    if (error instanceof Error) {
+      if (error.message.includes('Access denied')) {
+        console.log('Access denied error');
+        return res.status(403).json({ error: error.message });
+      }
+      if (error.message.includes('not found')) {
+        console.log('Not found error');
+        return res.status(404).json({ error: error.message });
+      }
+      if (error.message.includes('Invalid week start date')) {
+        console.log('Invalid date error');
+        return res.status(400).json({ error: error.message });
+      }
+      if (error.message.includes('must be a Monday')) {
+        console.log('Invalid start day error');
+        return res.status(400).json({ error: error.message });
+      }
+    }
+
+    console.error('Unexpected error getting shift status:', error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
 
 // ==================== WEEK SCHEDULE ROUTES ====================
 
@@ -241,4 +307,4 @@ router.delete('/:familyId/week-schedule/override', async (req: AuthenticatedRequ
   }
 });
 
-export default router; 
+export default router;

--- a/backend/src/services/week-schedule.service.ts
+++ b/backend/src/services/week-schedule.service.ts
@@ -14,6 +14,8 @@ import {
   WeekTemplateWithRelations,
   TaskOverride,
   TaskOverrideAction,
+  ShiftInfo,
+  ShiftStatusQueryParams,
 } from '../types/task.types';
 import { getWebSocketService } from './websocket.service';
 
@@ -889,4 +891,288 @@ export class WeekScheduleService {
 
     return weekOverride;
   }
-} 
+
+  // ==================== SHIFT STATUS ====================
+
+  /**
+   * Get the current shift status for a user
+   * Uses the same logic as the frontend ShiftIndicator
+   */
+  async getShiftStatus(
+    familyId: string,
+    userId: string,
+    params: ShiftStatusQueryParams = {}
+  ): Promise<ShiftInfo | null> {
+    // Get the week start date (default to current week)
+    const weekStartDate = params.weekStartDate || this.getCurrentWeekStart();
+
+    // Get the week schedule
+    const weekSchedule = await this.getWeekSchedule(familyId, { weekStartDate });
+
+    return this.calculateShiftInfo(weekSchedule, userId);
+  }
+
+  /**
+   * Calculate shift information for a user based on the week schedule
+   * This implements the same logic as the frontend ShiftIndicator
+   */
+  private async calculateShiftInfo(weekSchedule: ResolvedWeekSchedule, userId: string): Promise<ShiftInfo | null> {
+    const now = new Date();
+
+    // Get all tasks for the entire week, sorted by date and time
+    const allWeekTasks: Array<{ task: ResolvedTask; startTime: Date }> = [];
+
+    weekSchedule.days.forEach(day => {
+      day.tasks.forEach(task => {
+        const startTime = task.overrideTime || task.task.defaultStartTime;
+        const [hours, minutes] = startTime.split(':').map(Number);
+
+        // Parse the day date and set the task time
+        const dayDate = new Date(day.date.toISOString().split('T')[0] + 'T00:00:00');
+        const taskStart = new Date(dayDate);
+        taskStart.setHours(hours || 0, minutes || 0, 0, 0);
+
+        allWeekTasks.push({
+          task,
+          startTime: taskStart
+        });
+      });
+    });
+
+    // Sort all tasks by start time (across all days)
+    allWeekTasks.sort((a, b) => a.startTime.getTime() - b.startTime.getTime());
+
+    // Find the most recent task (closest in the past)
+    const pastTasks = allWeekTasks.filter(({ startTime }) => startTime <= now);
+
+    if (pastTasks.length === 0) {
+      // No tasks have started yet, find next task for current user
+      const nextUserTask = allWeekTasks.find(({ task }) => task.memberId === userId);
+      if (nextUserTask) {
+        const timeUntilStart = this.formatTimeRemaining(nextUserTask.startTime.getTime() - now.getTime());
+        return {
+          type: 'next',
+          startTime: nextUserTask.startTime,
+          timeUntilStart
+        };
+      }
+      return null;
+    }
+
+    // Get the most recent task that has started
+    const mostRecentTask = pastTasks[pastTasks.length - 1];
+
+    // Check if the most recent task is assigned to the current user
+    if (mostRecentTask.task.memberId === userId) {
+      // User is currently in shift - find when their shift ends (first task assigned to someone else)
+      const shiftEndTask = allWeekTasks.find(({ startTime, task }) =>
+        startTime > mostRecentTask.startTime && task.memberId !== userId
+      );
+
+      if (shiftEndTask) {
+        // Shift ends when first task assigned to someone else starts
+        const timeRemaining = this.formatTimeRemaining(shiftEndTask.startTime.getTime() - now.getTime());
+        return {
+          type: 'current',
+          endTime: shiftEndTask.startTime,
+          timeRemaining
+        };
+      } else {
+        // No more tasks assigned to others in the current week
+        // Check if we need to look at the next week for shift end
+        return await this.calculateCrossWeekShiftEnd(familyId, userId, now);
+      }
+    } else {
+      // User is not in shift - find their next task
+      const nextUserTask = allWeekTasks.find(({ startTime, task }) =>
+        startTime > now && task.memberId === userId
+      );
+
+      if (nextUserTask) {
+        const timeUntilStart = this.formatTimeRemaining(nextUserTask.startTime.getTime() - now.getTime());
+        return {
+          type: 'next',
+          startTime: nextUserTask.startTime,
+          timeUntilStart
+        };
+      }
+
+      // No more tasks for user this week - check next week
+      return await this.calculateCrossWeekNextShift(familyId, userId, now);
+    }
+  }
+
+  /**
+   * Calculate shift end when it spans across weeks
+   */
+  private async calculateCrossWeekShiftEnd(familyId: string, userId: string, now: Date): Promise<ShiftInfo | null> {
+    // Get the next week's schedule to find when shift ends
+    const nextWeekStart = new Date(now);
+    const daysUntilNextMonday = (8 - now.getDay()) % 7 || 7;
+    nextWeekStart.setDate(now.getDate() + daysUntilNextMonday);
+
+    const nextWeekStartStr = this.formatDateToString(nextWeekStart);
+
+    try {
+      const nextWeekSchedule = await this.getWeekSchedule(familyId, { weekStartDate: nextWeekStartStr });
+
+      // Get all tasks from next week
+      const nextWeekTasks: Array<{ task: ResolvedTask; startTime: Date }> = [];
+
+      nextWeekSchedule.days.forEach(day => {
+        day.tasks.forEach(task => {
+          const startTime = task.overrideTime || task.task.defaultStartTime;
+          const [hours, minutes] = startTime.split(':').map(Number);
+
+          const dayDate = new Date(day.date.toISOString().split('T')[0] + 'T00:00:00');
+          const taskStart = new Date(dayDate);
+          taskStart.setHours(hours || 0, minutes || 0, 0, 0);
+
+          nextWeekTasks.push({
+            task,
+            startTime: taskStart
+          });
+        });
+      });
+
+      // Sort by start time
+      nextWeekTasks.sort((a, b) => a.startTime.getTime() - b.startTime.getTime());
+
+      // Find first task assigned to someone else
+      const shiftEndTask = nextWeekTasks.find(({ task }) => task.memberId !== userId);
+
+      if (shiftEndTask) {
+        const timeRemaining = this.formatTimeRemaining(shiftEndTask.startTime.getTime() - now.getTime());
+        return {
+          type: 'current',
+          endTime: shiftEndTask.startTime,
+          timeRemaining
+        };
+      }
+
+      // If no tasks assigned to others in next week, default to end of next week
+      const endOfNextWeek = new Date(nextWeekStart);
+      endOfNextWeek.setDate(endOfNextWeek.getDate() + 6);
+      endOfNextWeek.setHours(23, 59, 59, 999);
+      const timeRemaining = this.formatTimeRemaining(endOfNextWeek.getTime() - now.getTime());
+      return {
+        type: 'current',
+        endTime: endOfNextWeek,
+        timeRemaining
+      };
+
+    } catch (error) {
+      // If we can't get next week's schedule, default to end of current week
+      const endOfWeek = new Date(now);
+      const daysUntilSunday = (7 - now.getDay()) % 7;
+      endOfWeek.setDate(now.getDate() + daysUntilSunday);
+      endOfWeek.setHours(23, 59, 59, 999);
+      const timeRemaining = this.formatTimeRemaining(endOfWeek.getTime() - now.getTime());
+      return {
+        type: 'current',
+        endTime: endOfWeek,
+        timeRemaining
+      };
+    }
+  }
+
+  /**
+   * Calculate next shift when it's in the following week
+   */
+  private async calculateCrossWeekNextShift(familyId: string, userId: string, now: Date): Promise<ShiftInfo | null> {
+    // Get the next week's schedule to find user's next shift
+    const nextWeekStart = new Date(now);
+    const daysUntilNextMonday = (8 - now.getDay()) % 7 || 7;
+    nextWeekStart.setDate(now.getDate() + daysUntilNextMonday);
+
+    const nextWeekStartStr = this.formatDateToString(nextWeekStart);
+
+    try {
+      const nextWeekSchedule = await this.getWeekSchedule(familyId, { weekStartDate: nextWeekStartStr });
+
+      // Get all tasks from next week
+      const nextWeekTasks: Array<{ task: ResolvedTask; startTime: Date }> = [];
+
+      nextWeekSchedule.days.forEach(day => {
+        day.tasks.forEach(task => {
+          const startTime = task.overrideTime || task.task.defaultStartTime;
+          const [hours, minutes] = startTime.split(':').map(Number);
+
+          const dayDate = new Date(day.date.toISOString().split('T')[0] + 'T00:00:00');
+          const taskStart = new Date(dayDate);
+          taskStart.setHours(hours || 0, minutes || 0, 0, 0);
+
+          nextWeekTasks.push({
+            task,
+            startTime: taskStart
+          });
+        });
+      });
+
+      // Sort by start time
+      nextWeekTasks.sort((a, b) => a.startTime.getTime() - b.startTime.getTime());
+
+      // Find first task assigned to current user
+      const nextUserTask = nextWeekTasks.find(({ task }) => task.memberId === userId);
+
+      if (nextUserTask) {
+        const timeUntilStart = this.formatTimeRemaining(nextUserTask.startTime.getTime() - now.getTime());
+        return {
+          type: 'next',
+          startTime: nextUserTask.startTime,
+          timeUntilStart
+        };
+      }
+
+      return null; // No tasks for user in next week either
+    } catch (error) {
+      return null; // Can't determine next week's schedule
+    }
+  }
+
+  /**
+   * Get the current week start date (Monday)
+   */
+  private getCurrentWeekStart(): string {
+    const now = new Date();
+    const dayOfWeek = now.getDay();
+    const daysToMonday = dayOfWeek === 0 ? -6 : 1 - dayOfWeek; // Sunday = 0, Monday = 1
+    const monday = new Date(now);
+    monday.setDate(now.getDate() + daysToMonday);
+    return this.formatDateToString(monday);
+  }
+
+  /**
+   * Format a date to YYYY-MM-DD string
+   */
+  private formatDateToString(date: Date): string {
+    return date.toISOString().split('T')[0];
+  }
+
+  /**
+   * Format time remaining in a human-readable format
+   */
+  private formatTimeRemaining(milliseconds: number): string {
+    const totalMinutes = Math.floor(milliseconds / (1000 * 60));
+    const hours = Math.floor(totalMinutes / 60);
+    const minutes = totalMinutes % 60;
+    const days = Math.floor(hours / 24);
+    const remainingHours = hours % 24;
+
+    if (days > 0) {
+      if (remainingHours > 0) {
+        return `${days}d ${remainingHours}h`;
+      }
+      return `${days}d`;
+    }
+
+    if (hours > 0) {
+      if (minutes > 0) {
+        return `${hours}h ${minutes}m`;
+      }
+      return `${hours}h`;
+    }
+
+    return `${minutes}m`;
+  }
+}

--- a/backend/src/services/week-schedule.service.ts
+++ b/backend/src/services/week-schedule.service.ts
@@ -909,14 +909,14 @@ export class WeekScheduleService {
     // Get the week schedule
     const weekSchedule = await this.getWeekSchedule(familyId, { weekStartDate });
 
-    return this.calculateShiftInfo(weekSchedule, userId);
+    return this.calculateShiftInfo(weekSchedule, familyId, userId);
   }
 
   /**
    * Calculate shift information for a user based on the week schedule
    * This implements the same logic as the frontend ShiftIndicator
    */
-  private async calculateShiftInfo(weekSchedule: ResolvedWeekSchedule, userId: string): Promise<ShiftInfo | null> {
+  private async calculateShiftInfo(weekSchedule: ResolvedWeekSchedule, familyId: string, userId: string): Promise<ShiftInfo | null> {
     const now = new Date();
 
     // Get all tasks for the entire week, sorted by date and time

--- a/backend/src/types/task.types.ts
+++ b/backend/src/types/task.types.ts
@@ -603,6 +603,20 @@ export interface WeekScheduleQueryParams {
   weekStartDate: string; // ISO date string (YYYY-MM-DD) for the Monday of the week
 }
 
+// Shift status information
+export interface ShiftInfo {
+  type: 'current' | 'next';
+  startTime?: Date;
+  endTime?: Date;
+  timeUntilStart?: string;
+  timeRemaining?: string;
+}
+
+// Query parameters for getting shift status
+export interface ShiftStatusQueryParams {
+  weekStartDate?: string; // Optional - defaults to current week
+}
+
 // DTO for applying week overrides
 export interface ApplyWeekOverrideDto {
   weekStartDate: string; // ISO date string (YYYY-MM-DD) for the Monday of the week

--- a/frontend/src/components/calendar/WeeklyCalendar.tsx
+++ b/frontend/src/components/calendar/WeeklyCalendar.tsx
@@ -63,18 +63,14 @@ export const WeeklyCalendar: React.FC<WeeklyCalendarProps> = ({ className }) => 
   // Load shift status from backend
   const loadShiftStatus = useCallback(async () => {
     if (!currentFamily) {
-      console.log('❌ No currentFamily, skipping shift status load');
       return;
     }
 
-    console.log('🔄 Loading shift status...', { familyId: currentFamily.id, weekStart: currentWeekStart });
     try {
       // Pass currentWeekStart even if undefined - backend will use current week
       const response = await weekScheduleApi.getShiftStatus(currentFamily.id, currentWeekStart || undefined);
-      console.log('✅ Shift status loaded:', response.data);
       setShiftStatus(response.data.shiftInfo);
     } catch (error) {
-      console.error('❌ Failed to load shift status:', error);
       setShiftStatus(null);
     }
   }, [currentFamily, currentWeekStart]);
@@ -129,7 +125,6 @@ export const WeeklyCalendar: React.FC<WeeklyCalendarProps> = ({ className }) => 
 
   // Load week schedule when currentWeekStart changes
   useEffect(() => {
-    console.log('📅 Week effect:', { currentFamily: !!currentFamily, currentWeekStart });
     if (currentFamily && currentWeekStart) {
       loadWeekSchedule(currentWeekStart);
       loadShiftStatus();

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -171,18 +171,24 @@ export const dayTemplateApi = {
 
 export const weekScheduleApi = {
   async getWeekSchedule(familyId: string, weekStartDate: string) {
-    return await apiClient.get(`/families/${familyId}/week-schedule`, { 
-      params: { weekStartDate } 
+    return await apiClient.get(`/families/${familyId}/week-schedule`, {
+      params: { weekStartDate }
     });
   },
-  
+
   async applyWeekOverride(familyId: string, data: any) {
     return await apiClient.post(`/families/${familyId}/week-schedule/override`, data);
   },
-  
+
   async removeWeekOverride(familyId: string, weekStartDate: string) {
     return await apiClient.delete(`/families/${familyId}/week-schedule/override`, {
       params: { weekStartDate }
+    });
+  },
+
+  async getShiftStatus(familyId: string, weekStartDate?: string) {
+    return await apiClient.get(`/families/${familyId}/shift-status`, {
+      params: weekStartDate ? { weekStartDate } : {}
     });
   }
 };

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -412,5 +412,14 @@ export interface DuplicateWeekTemplateData {
   name: string;
 }
 
+// Shift status types
+export interface ShiftInfo {
+  type: 'current' | 'next';
+  startTime?: string; // ISO string
+  endTime?: string; // ISO string
+  timeUntilStart?: string;
+  timeRemaining?: string;
+}
+
 // Export analytics types
-export * from './analytics'; 
+export * from './analytics';

--- a/mobile/src/components/ui/ShiftIndicator.tsx
+++ b/mobile/src/components/ui/ShiftIndicator.tsx
@@ -112,269 +112,12 @@ export const ShiftIndicator: React.FC = () => {
       ) : shiftInfo.type === 'current' ? (
         <Text style={styles.singleLineText}>
           <Text style={[styles.statusText, styles.currentShift]}>Shift ends </Text>
-          task,
-          startTime: taskStart
-        });
-      });
-    });
-
-    // Sort all tasks by start time (across all days)
-    allWeekTasks.sort((a, b) => a.startTime.getTime() - b.startTime.getTime());
-
-    // Find the most recent task (closest in the past)
-    const pastTasks = allWeekTasks.filter(({ startTime }) => startTime <= now);
-    
-    if (pastTasks.length === 0) {
-      // No tasks have started yet, find next task for current user
-      const nextUserTask = allWeekTasks.find(({ task }) => task.memberId === user.id);
-      if (nextUserTask) {
-        const timeUntilStart = formatTimeRemaining(nextUserTask.startTime.getTime() - now.getTime());
-        return {
-          type: 'next',
-          startTime: nextUserTask.startTime,
-          timeUntilStart
-        };
-      }
-      return null;
-    }
-
-    // Get the most recent task (last in pastTasks array)
-    const mostRecentTask = pastTasks[pastTasks.length - 1];
-    if (!mostRecentTask) {
-      return null;
-    }
-    
-    // Check if the most recent task is assigned to the current user
-    if (mostRecentTask.task.memberId === user.id) {
-      // User is currently in shift - find when their shift ends (first task assigned to someone else)
-      const shiftEndTask = allWeekTasks.find(({ startTime, task }) => 
-        startTime > mostRecentTask.startTime && task.memberId !== user.id
-      );
-      
-      if (shiftEndTask) {
-        // Shift ends when first task assigned to someone else starts
-        const timeRemaining = formatTimeRemaining(shiftEndTask.startTime.getTime() - now.getTime());
-        return {
-          type: 'current',
-          endTime: shiftEndTask.startTime,
-          timeRemaining
-        };
-      } else {
-        // No more tasks assigned to others in the current week
-        // Check if we need to look at the next week for shift end
-        return await calculateCrossWeekShiftEnd(now);
-      }
-    }
-    // User is not in shift - find their next task
-    const nextUserTask = allWeekTasks.find(({ startTime, task }) => 
-      startTime > now && task.memberId === user.id
-    );
-    
-    if (nextUserTask) {
-      const timeUntilStart = formatTimeRemaining(nextUserTask.startTime.getTime() - now.getTime());
-      return {
-        type: 'next',
-        startTime: nextUserTask.startTime,
-        timeUntilStart
-      };
-    }
-    
-    // No more tasks for user this week - check next week
-    return await calculateCrossWeekNextShift(now);
-  };
-
-  const calculateCrossWeekShiftEnd = async (now: Date): Promise<ShiftInfo> => {
-    // Get the next week's schedule to find when the shift ends
-    const nextWeekStart = new Date(now);
-    const daysUntilNextMonday = (8 - now.getDay()) % 7 || 7;
-    nextWeekStart.setDate(now.getDate() + daysUntilNextMonday);
-    
-    const nextWeekStartStr = getMonday(nextWeekStart);
-    
-    try {
-      const response = await weekScheduleApi.getWeekSchedule(currentFamily!.id, nextWeekStartStr);
-      const nextWeekSchedule: ResolvedWeekSchedule = response.data;
-      
-      // Get all tasks from next week
-      const nextWeekTasks: Array<{ task: ResolvedTask; startTime: Date }> = [];
-      
-      nextWeekSchedule.days.forEach(day => {
-        day.tasks.forEach(task => {
-          const startTime = task.overrideTime || task.task.defaultStartTime;
-          const [hours, minutes] = startTime.split(':').map(Number);
-          
-          const dayDate = new Date(day.date + 'T00:00:00');
-          const taskStart = new Date(dayDate);
-          taskStart.setHours(hours || 0, minutes || 0, 0, 0);
-          
-          nextWeekTasks.push({
-            task,
-            startTime: taskStart
-          });
-        });
-      });
-      
-      // Sort by start time
-      nextWeekTasks.sort((a, b) => a.startTime.getTime() - b.startTime.getTime());
-      
-      // Find first task assigned to someone else
-      const shiftEndTask = nextWeekTasks.find(({ task }) => task.memberId !== user!.id);
-      
-      if (shiftEndTask) {
-        const timeRemaining = formatTimeRemaining(shiftEndTask.startTime.getTime() - now.getTime());
-        return {
-          type: 'current',
-          endTime: shiftEndTask.startTime,
-          timeRemaining
-        };
-      } else {
-        // Shift continues through next week too - end at end of next week
-        const endOfNextWeek = new Date(nextWeekStart);
-        endOfNextWeek.setDate(nextWeekStart.getDate() + 6); // Go to next Sunday
-        endOfNextWeek.setHours(23, 59, 59, 999);
-        const timeRemaining = formatTimeRemaining(endOfNextWeek.getTime() - now.getTime());
-        return {
-          type: 'current',
-          endTime: endOfNextWeek,
-          timeRemaining
-        };
-      }
-    } catch (error) {
-      // If we can't get next week's schedule, default to end of current week
-      const endOfWeek = new Date(now);
-      const daysUntilSunday = (7 - now.getDay()) % 7;
-      endOfWeek.setDate(now.getDate() + daysUntilSunday);
-      endOfWeek.setHours(23, 59, 59, 999);
-      const timeRemaining = formatTimeRemaining(endOfWeek.getTime() - now.getTime());
-      return {
-        type: 'current',
-        endTime: endOfWeek,
-        timeRemaining
-      };
-    }
-  };
-
-  const calculateCrossWeekNextShift = async (now: Date): Promise<ShiftInfo | null> => {
-    // Get the next week's schedule to find user's next shift
-    const nextWeekStart = new Date(now);
-    const daysUntilNextMonday = (8 - now.getDay()) % 7 || 7;
-    nextWeekStart.setDate(now.getDate() + daysUntilNextMonday);
-    
-    const nextWeekStartStr = getMonday(nextWeekStart);
-    
-    try {
-      const response = await weekScheduleApi.getWeekSchedule(currentFamily!.id, nextWeekStartStr);
-      const nextWeekSchedule: ResolvedWeekSchedule = response.data;
-      
-      // Get all tasks from next week
-      const nextWeekTasks: Array<{ task: ResolvedTask; startTime: Date }> = [];
-      
-      nextWeekSchedule.days.forEach(day => {
-        day.tasks.forEach(task => {
-          const startTime = task.overrideTime || task.task.defaultStartTime;
-          const [hours, minutes] = startTime.split(':').map(Number);
-          
-          const dayDate = new Date(day.date + 'T00:00:00');
-          const taskStart = new Date(dayDate);
-          taskStart.setHours(hours || 0, minutes || 0, 0, 0);
-          
-          nextWeekTasks.push({
-            task,
-            startTime: taskStart
-          });
-        });
-      });
-      
-      // Sort by start time
-      nextWeekTasks.sort((a, b) => a.startTime.getTime() - b.startTime.getTime());
-      
-      // Find first task assigned to current user
-      const nextUserTask = nextWeekTasks.find(({ task }) => task.memberId === user!.id);
-      
-      if (nextUserTask) {
-        const timeUntilStart = formatTimeRemaining(nextUserTask.startTime.getTime() - now.getTime());
-        return {
-          type: 'next',
-          startTime: nextUserTask.startTime,
-          timeUntilStart
-        };
-      }
-      
-      return null; // No tasks for user in next week either
-    } catch (error) {
-      return null; // Can't determine next week's schedule
-    }
-  };
-
-  const formatTimeRemaining = (milliseconds: number): string => {
-    const totalMinutes = Math.floor(milliseconds / (1000 * 60));
-    const hours = Math.floor(totalMinutes / 60);
-    const minutes = totalMinutes % 60;
-
-    if (hours > 0) {
-      return `${hours}h ${minutes}m`;
-    }
-    return `${minutes}m`;
-  };
-
-  const formatTime = (date: Date): string => {
-    return date.toLocaleTimeString([], { 
-      hour: 'numeric', 
-      minute: '2-digit',
-      hour12: true 
-    });
-  };
-
-  const formatTimeWithDate = (date: Date): string => {
-    const now = new Date();
-    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-    const targetDate = new Date(date.getFullYear(), date.getMonth(), date.getDate());
-    
-    const timeDiff = targetDate.getTime() - today.getTime();
-    const daysDiff = Math.floor(timeDiff / (1000 * 60 * 60 * 24));
-    
-    const timeStr = formatTime(date);
-    
-    if (daysDiff === 0) {
-      return timeStr; // Today - no need to specify
-    } else if (daysDiff === 1) {
-      return `${timeStr} Tomorrow`;
-    } else if (daysDiff === -1) {
-      return `${timeStr} Yesterday`;
-    } else if (daysDiff > 1 && daysDiff <= 6) {
-      const dayName = date.toLocaleDateString([], { weekday: 'long' });
-      return `${timeStr} ${dayName}`;
-    } else {
-      // For dates beyond this week, show the actual date
-      const dateStr = date.toLocaleDateString([], { month: 'short', day: 'numeric' });
-      return `${timeStr} ${dateStr}`;
-    }
-  };
-
-  // Always render the container to prevent layout shifts
-  return (
-    <View style={styles.container}>
-      {(!currentFamily || !user) ? (
-        // Don't show anything if no family/user context
-        <View style={styles.placeholder} />
-      ) : isLoading && !shiftInfo ? (
-        // Only show loading on initial load
-        <Text style={styles.singleLineText}>Loading shifts...</Text>
-      ) : !shiftInfo ? (
-        <Text style={styles.singleLineText}>No shifts scheduled</Text>
-      ) : shiftInfo.type === 'current' ? (
-        <Text style={styles.singleLineText}>
-          <Text style={[styles.statusText, styles.currentShift]}>Shift ends </Text>
-          <Text style={styles.timeText}>
-            {formatTimeWithDate(shiftInfo.endTime!)} ({shiftInfo.timeRemaining} left)
-          </Text>
+          {shiftInfo.timeRemaining || 'soon'}
         </Text>
       ) : (
         <Text style={styles.singleLineText}>
           <Text style={[styles.statusText, styles.nextShift]}>Next shift </Text>
-          <Text style={styles.timeText}>
-            {formatTimeWithDate(shiftInfo.startTime!)} (in {shiftInfo.timeUntilStart})
-          </Text>
+          {shiftInfo.timeUntilStart || 'soon'}
         </Text>
       )}
     </View>
@@ -385,18 +128,18 @@ const styles = StyleSheet.create({
   container: {
     flexDirection: 'row',
     alignItems: 'center',
-    minHeight: 20, // Ensure consistent height
+    minHeight: 20,
     justifyContent: 'flex-start',
   },
   placeholder: {
     width: 0,
-    height: 20, // Match minHeight for consistency
+    height: 20,
   },
   singleLineText: {
     fontSize: 14,
     color: 'rgba(255, 255, 255, 0.9)',
     fontWeight: '500',
-    lineHeight: 20, // Consistent line height
+    lineHeight: 20,
   },
   statusText: {
     fontWeight: '600',
@@ -406,10 +149,10 @@ const styles = StyleSheet.create({
     lineHeight: 20,
   },
   currentShift: {
-    color: '#86efac', // Light green for current shift
+    color: '#86efac',
   },
   nextShift: {
-    color: '#93c5fd', // Light blue for next shift
+    color: '#93c5fd',
   },
   timeText: {
     fontSize: 14,
@@ -417,4 +160,4 @@ const styles = StyleSheet.create({
     fontWeight: '500',
     lineHeight: 20,
   },
-}); 
+});

--- a/mobile/src/services/api.ts
+++ b/mobile/src/services/api.ts
@@ -91,18 +91,24 @@ export const familyApi = {
 // Week Schedule API
 export const weekScheduleApi = {
   async getWeekSchedule(familyId: string, weekStartDate: string) {
-    return await apiClient.get(`/families/${familyId}/week-schedule`, { 
-      params: { weekStartDate } 
+    return await apiClient.get(`/families/${familyId}/week-schedule`, {
+      params: { weekStartDate }
     });
   },
-  
+
   async applyWeekOverride(familyId: string, data: any) {
     return await apiClient.post(`/families/${familyId}/week-schedule/override`, data);
   },
-  
+
   async removeWeekOverride(familyId: string, weekStartDate: string) {
     return await apiClient.delete(`/families/${familyId}/week-schedule/override`, {
       params: { weekStartDate }
+    });
+  },
+
+  async getShiftStatus(familyId: string, weekStartDate?: string) {
+    return await apiClient.get(`/families/${familyId}/shift-status`, {
+      params: weekStartDate ? { weekStartDate } : {}
     });
   }
 };

--- a/mobile/src/types/index.ts
+++ b/mobile/src/types/index.ts
@@ -327,3 +327,12 @@ export interface CreateWeekTemplateDayData {
 export interface UpdateWeekTemplateDayData {
   dayTemplateId: string;
 }
+
+// Shift status types
+export interface ShiftInfo {
+  type: 'current' | 'next';
+  startTime?: string; // ISO string
+  endTime?: string; // ISO string
+  timeUntilStart?: string;
+  timeRemaining?: string;
+}


### PR DESCRIPTION
## Overview
Centralized the sophisticated shift detection logic from ShiftIndicator into a backend service to ensure consistency across frontend and mobile applications.

## Backend Changes
- **New API Endpoint**: GET /api/families/:familyId/shift-status
- **New Service Method**: WeekScheduleService.getShiftStatus()
- **Enhanced Types**: Added ShiftInfo and ShiftStatusQueryParams interfaces
- **Sophisticated Algorithm**: Implements the correct shift detection logic:
  - Analyzes all tasks across the entire week
  - Finds the most recent task that has started
  - Determines if user is 'in shift' based on task ownership continuity
  - Handles cross-week shift calculations
  - Returns formatted time strings (e.g., '2h 30m', '1h 15m')

## Frontend Changes
- **Updated WeeklyCalendar**: Replaced incorrect local shift logic with backend API calls
- **Enhanced API Client**: Added getShiftStatus() method to weekScheduleApi
- **Improved Accuracy**: Now uses precise task-level checking for 'live' indicators
- **Fixed Bug**: Resolved issue where all user tasks showed as 'live' instead of just the currently active task

## Mobile Changes
- **Updated ShiftIndicator**: Simplified to use backend API instead of duplicated logic
- **Enhanced API Client**: Added getShiftStatus() method to mobile weekScheduleApi
- **Consistent Behavior**: Now matches frontend shift detection exactly

## Benefits
- **Consistency**: All clients use identical shift detection algorithm
- **Maintainability**: Logic centralized in one location
- **Accuracy**: Uses sophisticated algorithm instead of simple time-based checking
- **Performance**: Reduces client-side computation
- **Reusability**: Easy to extend to new features or platforms

## API Response Format

Fixes: Incorrect shift status detection in WeeklyCalendar
Resolves: Inconsistent shift logic between frontend and mobile