### PR TITLE
fix: remove unnecessary @ts-ignore comments from csrf middleware

### DIFF
--- a/backend/src/middleware/csrf.middleware.ts
+++ b/backend/src/middleware/csrf.middleware.ts
@@ -1,7 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-// @ts-ignore - temporarily unused due to disabled CSRF
 import crypto from 'crypto';
-// @ts-ignore - temporarily unused due to disabled CSRF
 import { i18next } from '../config/i18n';
 
 export interface CSRFRequest extends Request {
@@ -36,7 +34,6 @@ function generateRandomCSRFToken(): string {
 /**
  * Extract CSRF token from request (header or body)
  */
-// @ts-ignore - temporarily unused due to disabled CSRF
 function extractCSRFToken(req: Request): string | undefined {
   // Check header first (preferred)
   const headerToken = req.headers[CSRF_HEADER_NAME] as string;


### PR DESCRIPTION
## Summary
- Removed 3 unnecessary `@ts-ignore` comments from csrf.middleware.ts
- These comments were incorrectly marking imports as unused when they are actively used in the code

## Context
This is Phase 1, Step 2 of the backend enhancement plan: Fix TypeScript Issues

## Changes Made
1. Removed `@ts-ignore` comment from `crypto` import (line 2)
2. Removed `@ts-ignore` comment from `i18next` import (line 4)  
3. Removed `@ts-ignore` comment from `extractCSRFToken` function (line 39)

## Verification
✅ TypeScript compilation: No errors (`npm run build`)
✅ Linting: No issues (`npm run lint`)
✅ Tests: All 136 tests passing (`npm test`)
✅ No remaining `@ts-ignore` comments in source code

## Notes
- Both `crypto` and `i18next` imports are used in the CSRF middleware implementation
- The `extractCSRFToken` function is also actively used
- These @ts-ignore comments appear to be leftover from earlier development

This small but important change improves code quality by removing unnecessary TypeScript suppression comments.

🤖 Generated with [Claude Code](https://claude.ai/code)